### PR TITLE
Award 781 - Qualification offer updates are not associating to the latest qualification version

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
@@ -80,19 +80,25 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                                         .ToListAsync();
                 var userCreatedOfferIds = userCreatedOffers.Select(s => s.QualificationVersion.QualificationId).ToList();
 
-                // Funding offers not to be updated as they have been approved
-                var noTouchyList = await _applicationDbContext.QualificationFundingFeedbacks
-                                        .Include(i => i.QualificationVersion)
-                                        .Where(w => w.Approved ?? false)
-                                        .Select(s => s.QualificationVersion.QualificationId)
-                                        .ToListAsync();
+                // Previously, only records with qualifications offering feedback that were not approved were updated.
+                // Now, all offer records are updated regardless of their approval status.
+                
+                //var noTouchyList = await _applicationDbContext.QualificationFundingFeedbacks
+                //        .Include(i => i.QualificationVersion)
+                //        .Where(w => w.Approved ?? false)
+                //        .Select(s => s.QualificationVersion.QualificationId)
+                //        .ToListAsync();
 
                 // These are quals that have imported offers, but no user created offers
-                var qualsMissingFunding = importedOfferIds.Except(userCreatedOfferIds).Except(noTouchyList).ToList();
+                //var qualsMissingFunding = importedOfferIds.Except(userCreatedOfferIds).Except(noTouchyList).ToList();
+                var qualsMissingFunding = importedOfferIds.Except(userCreatedOfferIds).ToList();
+
                 _logger.LogInformation($"SeedFundingData -> Found {qualsMissingFunding.Count} quals missing offers");
 
                 // These are quals that have imported offers and user created offers
-                var qualsNeedUpdating = importedOfferIds.Except(qualsMissingFunding).Except(noTouchyList).ToList();
+                //var qualsNeedUpdating = importedOfferIds.Except(qualsMissingFunding).Except(noTouchyList).ToList();
+                var qualsNeedUpdating = importedOfferIds.Except(qualsMissingFunding).ToList();
+
                 _logger.LogInformation($"SeedFundingData -> Found {qualsNeedUpdating.Count} that might need updating");
 
                 var importRun = DateTime.Now;
@@ -174,7 +180,7 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                                     UserDisplayName = "FundedImport",
                                     Notes = $"Funded Import inserted {added} new offers",
                                     ActionTypeId = noActionNeededId
-                                });                                
+                                });   
                             }
                         }
                         else

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
@@ -239,54 +239,54 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             Assert.Equal(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalEndDate.Value), matchingFunding.EndDate);
         }
 
-        [Fact]
-        public async Task FundedQualificationWriter_ShouldNotUpdateFundings_WhenApproved()
-        {
-            //Arrange
-            await PopulateDbWithReferenceData();
-            var _service = CreateImportServiceWithDb();
+        //[Fact]
+        //public async Task FundedQualificationWriter_ShouldNotUpdateFundings_WhenApproved()
+        //{
+        //    //Arrange
+        //    await PopulateDbWithReferenceData();
+        //    var _service = CreateImportServiceWithDb();
 
-            var sets = new List<RecordSet>()
-            {
-                new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1001, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName1", QualificationNumber = "9001", VersionId = Guid.NewGuid() },
-                new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1002, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName2", QualificationNumber = "9002", VersionId = Guid.NewGuid() },
-                new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1003, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName3", QualificationNumber = "9003", VersionId = Guid.NewGuid() },
-                new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1004, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName4", QualificationNumber = "9004", VersionId = Guid.NewGuid() },
-            };
+        //    var sets = new List<RecordSet>()
+        //    {
+        //        new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1001, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName1", QualificationNumber = "9001", VersionId = Guid.NewGuid() },
+        //        new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1002, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName2", QualificationNumber = "9002", VersionId = Guid.NewGuid() },
+        //        new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1003, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName3", QualificationNumber = "9003", VersionId = Guid.NewGuid() },
+        //        new RecordSet() { OrgId = Guid.NewGuid(), OrganisationPrn = 1004, ProcessStatus = ProcessStageNoAction, QualId = Guid.NewGuid(), QualificationName = "QualName4", QualificationNumber = "9004", VersionId = Guid.NewGuid() },
+        //    };
 
-            foreach (var set in sets)
-            {
-                this.CreateQualificationRecordSet(set);
-            }
+        //    foreach (var set in sets)
+        //    {
+        //        this.CreateQualificationRecordSet(set);
+        //    }
 
-            List<FundedQualificationDTO> importedData = CreateImportedData(sets);
+        //    List<FundedQualificationDTO> importedData = CreateImportedData(sets);
 
-            await CreateFundingOffers(sets);
+        //    await CreateFundingOffers(sets);
 
-            //Act
-            var writeResult = await _service.WriteQualifications(importedData);
+        //    //Act
+        //    var writeResult = await _service.WriteQualifications(importedData);
 
-            Assert.True(writeResult);
-            var insertedOffers = await _dbContext.QualificationOffers
-                                    .ToListAsync();
+        //    Assert.True(writeResult);
+        //    var insertedOffers = await _dbContext.QualificationOffers
+        //                            .ToListAsync();
 
-            await ApproveFundingOffers(sets);
+        //    await ApproveFundingOffers(sets);
 
-            var seedResult = await _service.SeedFundingData();
+        //    var seedResult = await _service.SeedFundingData();
 
-            //Assert
-            Assert.True(seedResult);
-            var currentFundings = await _dbContext.QualificationFundings
-                                        .Include(i => i.QualificationVersion)
-                                            .ThenInclude(t => t.Qualification)
-                                        .Include(i => i.FundingOffer)
-                                        .ToListAsync();
-            Assert.Equal(4, currentFundings.Count);
-            var matchingFunding = currentFundings.Where(w => w.QualificationVersion.QualificationId == insertedOffers[0].Qualification.QualificationId).FirstOrDefault();
-            Assert.NotNull(matchingFunding);            
-            Assert.NotEqual(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalStartDate.Value), matchingFunding.StartDate);
-            Assert.NotEqual(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalEndDate.Value), matchingFunding.EndDate);
-        }
+        //    //Assert
+        //    Assert.True(seedResult);
+        //    var currentFundings = await _dbContext.QualificationFundings
+        //                                .Include(i => i.QualificationVersion)
+        //                                    .ThenInclude(t => t.Qualification)
+        //                                .Include(i => i.FundingOffer)
+        //                                .ToListAsync();
+        //    Assert.Equal(4, currentFundings.Count);
+        //    var matchingFunding = currentFundings.Where(w => w.QualificationVersion.QualificationId == insertedOffers[0].Qualification.QualificationId).FirstOrDefault();
+        //    Assert.NotNull(matchingFunding);            
+        //    Assert.NotEqual(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalStartDate.Value), matchingFunding.StartDate);
+        //    Assert.NotEqual(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalEndDate.Value), matchingFunding.EndDate);
+        //}
 
         private List<FundedQualificationDTO> CreateImportedData(List<RecordSet> sets, bool fundingAvailable = true)
         {


### PR DESCRIPTION
Previously, only records with qualifications offering feedback that were not approved were updated. Now, all offer records are updated regardless of their approval status.
I've left the previous implementation of the code commented as the business case will be reviewed by the next dev team and they may wish to filter approved offer feedback again in the near future.