### PR TITLE
Added in missing packages to support code coverage tooling and reporting 

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -16,7 +16,14 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />

--- a/src/SFA.DAS.AODP.Jobs/Program.cs
+++ b/src/SFA.DAS.AODP.Jobs/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 using SFA.DAS.AODP.Jobs.StartupExtensions;
+using System.Diagnostics.CodeAnalysis;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -34,3 +35,9 @@ builder.Services.AddServiceRegistrations(configuration);
 var app = builder.Build();
 
 app.Run();
+
+// Bit of a workaround for now, as we use top level statements for the Program.cs and the compiler automatically generates a Program class under the hood, we need a way to assign them [ExcludeFromCodeCoverage] attribute so having a partial class solves this
+[ExcludeFromCodeCoverage]
+public partial class Program
+{
+}

--- a/src/SFA.DAS.AODP.Jobs/Program.cs
+++ b/src/SFA.DAS.AODP.Jobs/Program.cs
@@ -36,8 +36,10 @@ var app = builder.Build();
 
 app.Run();
 
+#pragma warning disable S1118
 // Bit of a workaround for now, as we use top level statements for the Program.cs and the compiler automatically generates a Program class under the hood, we need a way to assign them [ExcludeFromCodeCoverage] attribute so having a partial class solves this
 [ExcludeFromCodeCoverage]
 public partial class Program
 {
 }
+#pragma warning restore S1118


### PR DESCRIPTION
Original Issue: The code coverage was not being calculated for the unit tests, the reason was due to a missing MSBuild package for coverlet (the tool we use to collect code coverage). The MSBuild package is one of the many different integration tools for code coverage and each one is used in parallel with the methodology of the code coverage tool being used. For example, in our CI pipelines which is defined at a shared template level, it uses the MSBuild approach to collect code coverage and therefore the MSBuild version of the coverlet package is required.

Fix: Add in the missing coverlet.msbuild package this allows the pipeline to run and collect code coverage. The coverlet.collector package allows the same but when using the VSTest platform so both are added for better flexibility between local and on the build boxes.