### PR TITLE
[AWARD-1178] - Refined eligibility logic to apply same changes applied in production

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationLevel.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationLevel.cs
@@ -1,5 +1,8 @@
-﻿namespace SFA.DAS.AODP.Common.Enum;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace SFA.DAS.AODP.Common.Enum;
+
+[ExcludeFromCodeCoverage]
 public record QualificationLevel(int? Code, string Value)
 {
     public static readonly QualificationLevel EntryLevel = new(null, "Entry Level");

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationLevel.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationLevel.cs
@@ -1,0 +1,23 @@
+﻿namespace SFA.DAS.AODP.Common.Enum;
+
+public record QualificationLevel(int? Code, string Value)
+{
+    public static readonly QualificationLevel EntryLevel = new(null, "Entry Level");
+    public static readonly QualificationLevel Level1And2 = new(null, "Level 1/Level 2");
+    public static readonly QualificationLevel Level1 = new(1, "Level 1");
+    public static readonly QualificationLevel Level2 = new(2, "Level 2");
+    public static readonly QualificationLevel Level3 = new(3, "Level 3");
+    public static readonly QualificationLevel Level4 = new(4, "Level 4");
+    public static readonly QualificationLevel Level5 = new(5, "Level 5");
+    public static readonly QualificationLevel Level6 = new(6, "Level 6");
+    public static readonly QualificationLevel Level7 = new(7, "Level 7");
+    public static readonly QualificationLevel Level8 = new(8, "Level 8");
+
+    private static readonly IReadOnlyCollection<QualificationLevel> Lookup =
+    [
+        EntryLevel, Level1And2, Level1, Level2, Level3, Level4, Level5, Level6, Level7, Level8
+    ];
+
+    public static QualificationLevel? TryFromString(string? level) =>
+        Lookup.SingleOrDefault(o => string.Equals(o.Value, level, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationReference.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationReference.cs
@@ -143,6 +143,7 @@ public static class QualificationReference
         return Regex.IsMatch(
             title,
             pattern,
-            RegexOptions.IgnoreCase);
+            RegexOptions.IgnoreCase,
+            TimeSpan.FromSeconds(30));
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationReference.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationReference.cs
@@ -1,43 +1,148 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 
-namespace SFA.DAS.AODP.Common.Enum
+namespace SFA.DAS.AODP.Common.Enum;
+
+public static class QualificationReference
 {
+    public static bool IsIneligibleType(string? type) =>
+        QualificationType.IsIneligible(type);
 
-    public class QualificationReference
+    public static bool HasIneligibleTitle(string? level, string? title)
     {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return false;
+        }
 
-        public const string EndPointAssessment = "End Point Assessment";
-        public static DateTime MinOperationalDate = new DateTime(2024, 8, 1);
+        var qualificationLevel = QualificationLevel.TryFromString(level);
+        if (qualificationLevel is null)
+        {
+            return Contains(title, CommonIneligibleTitles);
+        }
 
-        public static List<string> IneligibleQualifications =
-        [
-            "Certificate in Education",
-            "Professional Graduate Certificate in Education",
-            "Postgraduate Diploma in Education",
-            "ESOL International",
-            "degree",
-            "foundation degree",
-            "Higher National Certificate",
-            "Certificate of Higher Education",
-            "Higher National Diploma",
-            "Diploma of Higher Education",
-            "Diploma in Teaching"
-        ];
+        return HasIneligibleTitle(qualificationLevel, title);
+    }
 
-        public static List<string> IneligibleQualificationsShortForms =
-        [
-            "CertEd",
-            "PGCE",
-            "PGDE",
-            "HNC",
-            "Cert HE",
-            "HND",
-            "Dip HE",
-            "further education and skills"
-        ];
+    public static bool HasIneligibleTitle(QualificationLevel level, string title)
+    {
+        var trimmedTitle = title.Trim();
+
+        if (Contains(trimmedTitle, CommonIneligibleTitles))
+        {
+            return true;
+        }
+
+        if (!RulesByLevel.TryGetValue(level, out var rules))
+        {
+            return false;
+        }
+
+        return Contains(trimmedTitle, rules.Title.Select(x => x.Value)) ||
+               ContainsWholeWord(trimmedTitle, rules.Abbreviations.Select(x => x.Value));
+    }
+
+    private static readonly IReadOnlyCollection<string> CommonIneligibleTitles =
+    [
+        QualificationTitle.EsolInternational.Value
+    ];
+
+    private static readonly IReadOnlyDictionary<QualificationLevel, QualificationTitleRules> RulesByLevel =
+        new Dictionary<QualificationLevel, QualificationTitleRules>
+        {
+            [QualificationLevel.Level8] = new(
+                Title: [QualificationTitle.Doctor],
+                Abbreviations:
+                [
+                    QualificationTitle.PhD,
+                    QualificationTitle.EngD
+                ]),
+
+            [QualificationLevel.Level7] = new(
+                Title:
+                [
+                    QualificationTitle.Master,
+                    QualificationTitle.PostgraduateCertificateInEducation,
+                    QualificationTitle.PostgraduateDiplomaInEducation
+                ],
+                Abbreviations:
+                [
+                    QualificationTitle.MPhil,
+                    QualificationTitle.MSc,
+                    QualificationTitle.MA,
+                    QualificationTitle.MBA,
+                    QualificationTitle.MDes,
+                    QualificationTitle.MRes,
+                    QualificationTitle.PGCE,
+                    QualificationTitle.PGDE
+                ]),
+
+            [QualificationLevel.Level6] = new(
+                Title:
+                [
+                    QualificationTitle.Degree,
+                    QualificationTitle.ProfessionalGraduateCertificateInEducation,
+                    QualificationTitle.ProfessionalGraduateDiplomaInEducation
+                ],
+                Abbreviations:
+                [
+                    QualificationTitle.BA,
+                    QualificationTitle.BSc,
+                    QualificationTitle.BEd,
+                    QualificationTitle.BEng,
+                    QualificationTitle.BTech,
+                    QualificationTitle.PgCE,
+                    QualificationTitle.PgDE
+                ]),
+
+            [QualificationLevel.Level5] = new(
+                Title:
+                [
+                    QualificationTitle.FoundationDegree,
+                    QualificationTitle.HigherNationalDiploma,
+                    QualificationTitle.DiplomaOfHigherEducation,
+                    QualificationTitle.DiplomaInTeachingFurtherEducationAndSkills,
+                    QualificationTitle.DiplomaInTeachingFeAndSkills,
+                    QualificationTitle.DiplomaInTeachingFe,
+                    QualificationTitle.FurtherEducationAndSkills,
+                    QualificationTitle.CertificateInEducation,
+                    QualificationTitle.LearningAndSkillsTeacher
+                ],
+                Abbreviations:
+                [
+                    QualificationTitle.HND,
+                    QualificationTitle.DipHE,
+                    QualificationTitle.FdA,
+                    QualificationTitle.FdEng,
+                    QualificationTitle.FdSc,
+                    QualificationTitle.DiT,
+                    QualificationTitle.DIT,
+                    QualificationTitle.CertEd,
+                    QualificationTitle.CertED,
+                    QualificationTitle.LST
+                ]),
+
+            [QualificationLevel.Level4] = new(
+                Title:
+                [
+                    QualificationTitle.HigherNationalCertificate,
+                    QualificationTitle.CertificateOfHigherEducation
+                ],
+                Abbreviations: [QualificationTitle.HNC, QualificationTitle.CertHE])
+        };
+
+    private static bool Contains(string title, IEnumerable<string> values) =>
+        values.Any(value => title.Contains(value, StringComparison.OrdinalIgnoreCase));
+
+    private static bool ContainsWholeWord(string title, IEnumerable<string> values) =>
+        values.Any(value => ContainsWholeWord(title, value));
+
+    private static bool ContainsWholeWord(string title, string value)
+    {
+        var pattern = $@"\b{Regex.Escape(value)}\b";
+
+        return Regex.IsMatch(
+            title,
+            pattern,
+            RegexOptions.IgnoreCase);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitle.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitle.cs
@@ -1,5 +1,8 @@
-﻿namespace SFA.DAS.AODP.Common.Enum;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace SFA.DAS.AODP.Common.Enum;
+
+[ExcludeFromCodeCoverage]
 public record QualificationTitle(string Value)
 {
     public static readonly QualificationTitle EsolInternational = new("ESOL International");

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitle.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitle.cs
@@ -1,0 +1,66 @@
+﻿namespace SFA.DAS.AODP.Common.Enum;
+
+public record QualificationTitle(string Value)
+{
+    public static readonly QualificationTitle EsolInternational = new("ESOL International");
+
+    public static readonly QualificationTitle Doctor = new("doctor");
+    public static readonly QualificationTitle PhD = new("PhD");
+    public static readonly QualificationTitle EngD = new("EngD");
+
+    public static readonly QualificationTitle Master = new("master");
+    public static readonly QualificationTitle MPhil = new("MPhil");
+    public static readonly QualificationTitle MSc = new("MSc");
+    public static readonly QualificationTitle MA = new("MA");
+    public static readonly QualificationTitle MBA = new("MBA");
+    public static readonly QualificationTitle MDes = new("MDes");
+    public static readonly QualificationTitle MRes = new("MRes");
+
+    public static readonly QualificationTitle PostgraduateCertificateInEducation = new("Postgraduate Certificate in Education");
+
+    public static readonly QualificationTitle PostgraduateDiplomaInEducation = new("Postgraduate Diploma in Education");
+
+    public static readonly QualificationTitle PGCE = new("PGCE");
+    public static readonly QualificationTitle PGDE = new("PGDE");
+
+    public static readonly QualificationTitle Degree = new("degree");
+    public static readonly QualificationTitle BA = new("BA");
+    public static readonly QualificationTitle BSc = new("BSc");
+    public static readonly QualificationTitle BEd = new("BEd");
+    public static readonly QualificationTitle BEng = new("BEng");
+    public static readonly QualificationTitle BTech = new("BTech");
+
+    public static readonly QualificationTitle ProfessionalGraduateCertificateInEducation = new("Professional Graduate Certificate in Education");
+
+    public static readonly QualificationTitle ProfessionalGraduateDiplomaInEducation = new("Professional Graduate Diploma in Education");
+
+    public static readonly QualificationTitle PgCE = new("PgCE");
+    public static readonly QualificationTitle PgDE = new("PgDE");
+
+    public static readonly QualificationTitle FoundationDegree = new("foundation degree");
+    public static readonly QualificationTitle HigherNationalDiploma = new("Higher National Diploma");
+    public static readonly QualificationTitle DiplomaOfHigherEducation = new("Diploma of Higher Education");
+    public static readonly QualificationTitle HND = new("HND");
+    public static readonly QualificationTitle DipHE = new("Dip HE");
+    public static readonly QualificationTitle FdA = new("FdA");
+    public static readonly QualificationTitle FdEng = new("FdEng");
+    public static readonly QualificationTitle FdSc = new("FdSc");
+
+    public static readonly QualificationTitle DiplomaInTeachingFurtherEducationAndSkills = new("Diploma in Teaching (Further Education and Skills)");
+    public static readonly QualificationTitle DiplomaInTeachingFeAndSkills = new("Diploma in Teaching (FE and Skills)");
+
+    public static readonly QualificationTitle DiplomaInTeachingFe = new("Diploma in Teaching (FE)");
+    public static readonly QualificationTitle FurtherEducationAndSkills = new("Further Education and Skills");
+    public static readonly QualificationTitle CertificateInEducation = new("Certificate in Education");
+    public static readonly QualificationTitle LearningAndSkillsTeacher = new("Learning and Skills Teacher");
+    public static readonly QualificationTitle DiT = new("DiT");
+    public static readonly QualificationTitle DIT = new("DIT");
+    public static readonly QualificationTitle CertEd = new("CertEd");
+    public static readonly QualificationTitle CertED = new("CertED");
+    public static readonly QualificationTitle LST = new("LST");
+
+    public static readonly QualificationTitle HigherNationalCertificate = new("Higher National Certificate");
+    public static readonly QualificationTitle CertificateOfHigherEducation = new("Certificate of Higher Education");
+    public static readonly QualificationTitle HNC = new("HNC");
+    public static readonly QualificationTitle CertHE = new("Cert HE");
+}

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitleRules.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitleRules.cs
@@ -1,5 +1,8 @@
-﻿namespace SFA.DAS.AODP.Common.Enum;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace SFA.DAS.AODP.Common.Enum;
+
+[ExcludeFromCodeCoverage]
 public sealed record QualificationTitleRules(
     IReadOnlyCollection<QualificationTitle> Title,
     IReadOnlyCollection<QualificationTitle> Abbreviations);

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitleRules.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationTitleRules.cs
@@ -1,0 +1,5 @@
+﻿namespace SFA.DAS.AODP.Common.Enum;
+
+public sealed record QualificationTitleRules(
+    IReadOnlyCollection<QualificationTitle> Title,
+    IReadOnlyCollection<QualificationTitle> Abbreviations);

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationType.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/QualificationType.cs
@@ -1,0 +1,16 @@
+﻿namespace SFA.DAS.AODP.Common.Enum;
+
+public record QualificationType(string Value)
+{
+    public static readonly QualificationType EndPointAssessment = new("End-Point Assessment");
+
+    public static readonly QualificationType ApprenticeshipAssessmentQualification = new("Apprenticeship Assessment Qualification");
+
+    private static readonly IReadOnlyCollection<QualificationType> IneligibleTypes =
+    [
+        EndPointAssessment,
+        ApprenticeshipAssessmentQualification
+    ];
+
+    public static bool IsIneligible(string? type) => IneligibleTypes.Any(x => string.Equals(x.Value, type, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/ReferenceDataService.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/ReferenceDataService.cs
@@ -2,57 +2,51 @@
 using SFA.DAS.AODP.Infrastructure.Context;
 using SFA.DAS.AODP.Infrastructure.Interfaces;
 
-namespace SFA.DAS.AODP.Infrastructure.Services
+namespace SFA.DAS.AODP.Infrastructure.Services;
+
+public class ReferenceDataService : IReferenceDataService
 {
-    public class ReferenceDataService : IReferenceDataService
+    private readonly ILogger<ReferenceDataService> _logger;
+    private readonly IApplicationDbContext _applicationDbContext;
+    private Dictionary<string, Guid> _actionTypeMap = null!;
+    private Dictionary<string, Guid> _processStatusMap = null!;
+    private Dictionary<string, Guid> _lifecycleStageMap = null!;
+
+    public ReferenceDataService(ILogger<ReferenceDataService> logger, IApplicationDbContext applicationDbContext)
     {
-        private readonly ILogger<ReferenceDataService> _logger;
-        private readonly IApplicationDbContext _applicationDbContext;
-        private readonly Dictionary<string?, Guid> _actionTypeMap;
-        private readonly Dictionary<string?, Guid> _processStatusMap;
-        private readonly Dictionary<string?, Guid> _lifecycleStageMap;
+        _logger = logger;
+        _applicationDbContext = applicationDbContext ?? throw new ArgumentNullException(nameof(applicationDbContext));
 
-        public ReferenceDataService(ILogger<ReferenceDataService> logger, IApplicationDbContext applicationDbContext)
-        {
-            _logger = logger;
-            _applicationDbContext = applicationDbContext ?? throw new ArgumentNullException(nameof(applicationDbContext));
+        Initialise();
+    }
 
-            _actionTypeMap = _applicationDbContext.ActionType
-                .ToDictionary(a => a.Description, a => a.Id);
+    public Guid GetActionTypeId(string actionType)
+    {
+        return _actionTypeMap.TryGetValue(actionType, out var id)
+            ? id
+            : throw new KeyNotFoundException($"ActionTypeEnum {actionType} not found in the database.");
+    }
 
-            _processStatusMap = _applicationDbContext.ProcessStatus
-                                    .ToDictionary(a => a.Name, a => a.Id);
+    public Guid GetProcessStatusId(string processStatus)
+    {
+        return _processStatusMap.TryGetValue(processStatus, out var id)
+            ? id
+            : throw new KeyNotFoundException($"ActionTypeEnum {processStatus} not found in the database.");
+    }
 
-            _lifecycleStageMap = _applicationDbContext.LifecycleStages
-                .ToDictionary(a => a.Name, a => a.Id);
-        }
+    public Guid GetLifecycleStageId(string stage)
+    {
+        return _lifecycleStageMap.TryGetValue(stage, out var id)
+            ? id
+            : throw new KeyNotFoundException($"Lifecycle Stage {stage} not found in the database.");
+    }
 
-        public Guid GetActionTypeId(string actionType)
-        {
-            _logger.LogInformation($"[{nameof(ReferenceDataService)}] -> [{nameof(GetActionTypeId)}] -> Retrieving action type id for action type {actionType}...");
+    private void Initialise()
+    {
+        _logger.LogInformation("Initialising reference data.");
 
-            return _actionTypeMap.TryGetValue(actionType, out var id)
-                ? id
-                : throw new KeyNotFoundException($"ActionTypeEnum {actionType} not found in the database.");
-        }
-
-        public Guid GetProcessStatusId(string processStatus)
-        {
-            _logger.LogInformation($"[{nameof(ReferenceDataService)}] -> [{nameof(GetProcessStatusId)}] -> Retrieving process status id for action type {processStatus}...");
-
-            return _processStatusMap.TryGetValue(processStatus, out var id)
-                ? id
-                : throw new KeyNotFoundException($"ActionTypeEnum {processStatus} not found in the database.");
-        }
-
-        public Guid GetLifecycleStageId(string stage)
-        {
-            _logger.LogInformation($"[{nameof(ReferenceDataService)}] -> [{nameof(GetProcessStatusId)}] -> Retrieving Lifecycle Stage id for stage type {stage}...");
-
-            return _lifecycleStageMap.TryGetValue(stage, out var id)
-                ? id
-                : throw new KeyNotFoundException($"Lifecycle Stage {stage} not found in the database.");
-        }
-
+        _actionTypeMap = _applicationDbContext.ActionType.ToDictionary(a => a.Description!, a => a.Id)!;
+        _processStatusMap = _applicationDbContext.ProcessStatus.ToDictionary(a => a.Name!, a => a.Id)!;
+        _lifecycleStageMap = _applicationDbContext.LifecycleStages.ToDictionary(a => a.Name!, a => a.Id)!;
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
@@ -403,7 +403,6 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                 .With(w => w.OfferedInEngland, true)
                 .With(w => w.Glh, 5)
                 .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
                 .With(w => w.LifecycleStageId, LifeCycleStageNew)
                 .With(w => w.ProcessStatusId, record.ProcessStatus)
                 .With(w => w.QualificationId, record.QualId)

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundingEligibilityServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundingEligibilityServiceTests.cs
@@ -1,11 +1,4 @@
 ﻿using AutoFixture;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using Moq;
-using SFA.DAS.AODP.Common.Enum;
-using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Infrastructure.Context;
-using SFA.DAS.AODP.Jobs.Services;
 using SFA.DAS.AODP.Models.Qualification;
 
 namespace SFA.DAS.AODP.Jobs.Test.Application.Services
@@ -31,18 +24,17 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
 
             // Assert
             Assert.NotNull(fundingEligibilityService);
-            
+
         }
 
         [Fact]
         public void FundingEligibilityService_Eligible()
         {
             // Arrange
-            var qualification = _fixture.Build<QualificationDTO>()             
+            var qualification = _fixture.Build<QualificationDTO>()
                 .With(w => w.OfferedInEngland, true)
                 .With(w => w.Glh, 5)
                 .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
                 .Create();
 
             // Act
@@ -58,7 +50,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             // Arrange
             var qualification = _fixture.Build<QualificationDTO>()
                 .With(w => w.OfferedInEngland, true)
-                .With(w => w.IntentionToSeekFundingInEngland,true)
+                .With(w => w.IntentionToSeekFundingInEngland, true)
                 .With(w => w.Glh, 5)
                 .With(w => w.Tqt, 10)
                 .With(w => w.OperationalStartDate, DateTime.MinValue)
@@ -90,14 +82,26 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             Assert.False(eligible);
         }
 
-        [Fact]
-        public void FundingEligibilityService_Ineligible_GLH_Larger()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(0, 0)]
+        [InlineData(0, null)]
+        [InlineData(null, 0)]
+        [InlineData(null, 10)]
+        [InlineData(10, null)]
+        [InlineData(10, 10)]
+        [InlineData(10, 20)]
+        [InlineData(20, 10)]
+        public void FundingEligibilityService_GlhTqt_AnyValueEligible(int? glh, int? tqt)
         {
+            // Note: There used to be a criteria whereby the GLH and TQT values had to be greater than 0, and GLH had to be less than the TQT,
+            // but this was removed as part of the changes to the funding eligibility rules. This test ensures that any value for GLH and TQT (including 0) is now considered eligible, as long as the other criteria are met.
+
             // Arrange
             var qualification = _fixture.Build<QualificationDTO>()
                 .With(w => w.OfferedInEngland, true)
-                .With(w => w.Glh, 5)
-                .With(w => w.Tqt, 1)
+                .With(w => w.Glh, glh)
+                .With(w => w.Tqt, tqt)
                 .With(w => w.OperationalStartDate, DateTime.MinValue)
                 .Create();
 
@@ -105,103 +109,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var eligible = fundingEligibilityService.EligibleForFunding(qualification);
 
             // Assert
-            Assert.False(eligible);
-        }
-
-        [Theory]
-        [InlineData("Certificate in Education")]
-        [InlineData("Professional Graduate Certificate in Education")]
-        [InlineData("Postgraduate Diploma in Education")]
-        [InlineData("ESOL International")]
-        [InlineData("degree")]
-        [InlineData("foundation degree")]
-        [InlineData("Higher National Certificate")]
-        [InlineData("Certificate of Higher Education")]
-        [InlineData("Higher National Diploma")]
-        [InlineData("Diploma of Higher Education")]
-        [InlineData("Diploma in Teaching")]
-        public void FundingEligibilityService_Ineligible_MatchingTitle(string title)
-        {
-            // Arrange
-            var qualification = _fixture.Build<QualificationDTO>()
-                .With(w => w.Title, $"SomeText{title}EndText")
-                .With(w => w.OfferedInEngland, true)
-                .With(w => w.Glh, 5)
-                .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)           
-                .Create();
-
-            // Act
-            var eligible = fundingEligibilityService.EligibleForFunding(qualification);
-
-            // Assert
-            Assert.False(eligible);
-        }
-
-        [Theory]
-        [InlineData("CertEd")]
-        [InlineData("PGCE")]
-        [InlineData("PGDE")]
-        [InlineData("HNC")]
-        [InlineData("Cert HE")]
-        [InlineData("HND")]
-        [InlineData("Dip HE")]
-        [InlineData("further education and skills")]
-        public void FundingEligibilityService_Ineligible_MatchingShortTitle(string shortTitle)
-        {
-            // Arrange
-            var qualification = _fixture.Build<QualificationDTO>()
-                .With(w => w.Title, $"SomeText{shortTitle}EndText")
-                .With(w => w.OfferedInEngland, true)
-                .With(w => w.Glh, 5)
-                .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
-                .Create();
-
-            // Act
-            var eligible = fundingEligibilityService.EligibleForFunding(qualification);
-
-            // Assert
-            Assert.False(eligible);
-        }
-
-        [Fact]
-        public void FundingEligibilityService_RejectReason_NoAction()
-        {
-            // Arrange
-            var qualification = _fixture.Build<QualificationDTO>()
-                .With(w => w.OfferedInEngland, true)
-                .With(w => w.Glh, 5)
-                .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
-                .Create();
-
-            // Act
-            var reason = fundingEligibilityService.DetermineFailureReason(qualification);
-
-            // Assert
-            Assert.Equal(ImportReason.NoAction, reason);
-        }
-
-        [Fact]
-        public void FundingEligibilityService_RejectReason_NoHLG()
-        {
-            // Arrange
-            var qualification = _fixture.Build<QualificationDTO>()
-                .With(w => w.OfferedInEngland, true)
-                .With(w => w.Glh, 0)
-                .With(w => w.Tqt, 0)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
-                .Create();
-
-            // Act
-            var reason = fundingEligibilityService.DetermineFailureReason(qualification);
-
-            // Assert
-            Assert.Equal(ImportReason.NoGLHOrTQT, reason);
+            Assert.True(eligible);
         }
     }
 }
-
-
-

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
@@ -1033,7 +1033,6 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                 .With(w => w.OfferedInEngland, true)
                 .With(w => w.Glh, 5)
                 .With(w => w.Tqt, 10)
-                .With(w => w.OperationalStartDate, QualificationReference.MinOperationalDate)
                 .With(w => w.LifecycleStageId, LifeCycleStageNew)
                 .With(w => w.ProcessStatusId, processStatus)
                 .Create();            

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationReferenceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationReferenceTests.cs
@@ -1,0 +1,417 @@
+﻿namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services;
+
+public class QualificationReferenceTests
+{
+    [Theory]
+    [InlineData("End-Point Assessment")]
+    [InlineData("end-point assessment")]
+    [InlineData("Apprenticeship Assessment Qualification")]
+    [InlineData("apprenticeship assessment qualification")]
+    public void IsIneligibleType_WhenTypeIsIneligible_ReturnsTrue(string type)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationReference.IsIneligibleType(type);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("Some Other Type")]
+    public void IsIneligibleType_WhenTypeIsNotIneligible_ReturnsFalse(string? type)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationReference.IsIneligibleType(type);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void HasIneligibleTitle_WhenTitleIsNullOrWhiteSpace_ReturnsFalse(string? title)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(QualificationLevel.Level4.Value, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(null, "ESOL International")]
+    [InlineData("", "ESOL International")]
+    [InlineData("Unknown Level", "ESOL International")]
+    public void HasIneligibleTitle_WhenLevelIsUnknown_AndCommonRuleMatches_ReturnsTrue(string? level, string title)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(null, "Ordinary Qualification")]
+    [InlineData("", "Ordinary Qualification")]
+    [InlineData("Unknown Level", "Ordinary Qualification")]
+    public void HasIneligibleTitle_WhenLevelIsUnknown_AndCommonRuleDoesNotMatch_ReturnsFalse(string? level, string title)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_WhenKnownLevelHasNoConfiguredRules_AndNoCommonMatch_ReturnsFalse()
+    {
+        // Arrange
+        var level = QualificationLevel.Level3;
+        var title = "Ordinary Qualification";
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_WhenKnownLevelHasNoConfiguredRules_ButCommonMatchExists_ReturnsTrue()
+    {
+        // Arrange
+        var level = QualificationLevel.Level3;
+        var title = "ESOL International Certificate";
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_WhenTitleHasWhitespaceAndDifferentCase_ReturnsTrue()
+    {
+        // Arrange
+        var level = QualificationLevel.Level7;
+        var title = "   advanced MASTER in finance   ";
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level4TrueCases))]
+    public void HasIneligibleTitle_Level4_WhenTitleShouldBeIneligible_ReturnsTrue(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level4;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level4FalseCases))]
+    public void HasIneligibleTitle_Level4_WhenTitleShouldNotBeIneligible_ReturnsFalse(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level4;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level5TrueCases))]
+    public void HasIneligibleTitle_Level5_WhenTitleShouldBeIneligible_ReturnsTrue(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level5;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level5FalseCases))]
+    public void HasIneligibleTitle_Level5_WhenTitleShouldNotBeIneligible_ReturnsFalse(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level5;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level6TrueCases))]
+    public void HasIneligibleTitle_Level6_WhenTitleShouldBeIneligible_ReturnsTrue(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level6;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level6FalseCases))]
+    public void HasIneligibleTitle_Level6_WhenTitleShouldNotBeIneligible_ReturnsFalse(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level6;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level7TrueCases))]
+    public void HasIneligibleTitle_Level7_WhenTitleShouldBeIneligible_ReturnsTrue(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level7;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level7FalseCases))]
+    public void HasIneligibleTitle_Level7_WhenTitleShouldNotBeIneligible_ReturnsFalse(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level7;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level8TrueCases))]
+    public void HasIneligibleTitle_Level8_WhenTitleShouldBeIneligible_ReturnsTrue(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level8;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(Level8FalseCases))]
+    public void HasIneligibleTitle_Level8_WhenTitleShouldNotBeIneligible_ReturnsFalse(string title)
+    {
+        // Arrange
+        var level = QualificationLevel.Level8;
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_StringOverload_WhenKnownLevelMatchesConfiguredRule_ReturnsTrue()
+    {
+        // Arrange
+        var level = QualificationLevel.Level5.Value;
+        var title = "Higher National Diploma in Business";
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_StringOverload_WhenKnownLevelDoesNotMatchConfiguredRule_ReturnsFalse()
+    {
+        // Arrange
+        var level = QualificationLevel.Level5.Value;
+        var title = "Ordinary Diploma in Business";
+
+        // Act
+        var result = QualificationReference.HasIneligibleTitle(level, title);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasIneligibleTitle_WhenLevelAndStringOverloadsUsedWithSameInputs_ReturnSameResult()
+    {
+        // Arrange
+        var level = QualificationLevel.Level7;
+        var title = "Award in MBA";
+
+        // Act
+        var resultFromLevelOverload = QualificationReference.HasIneligibleTitle(level, title);
+        var resultFromStringOverload = QualificationReference.HasIneligibleTitle(level.Value, title);
+
+        // Assert
+        Assert.Equal(resultFromLevelOverload, resultFromStringOverload);
+    }
+
+    public static IEnumerable<object[]> Level4TrueCases()
+    {
+        yield return ["Higher National Certificate in Engineering"];
+        yield return ["Certificate of Higher Education in Science"];
+        yield return ["Cert HE in Business"];
+        yield return ["Award in HNC"];
+        yield return ["ESOL International Level 4"];
+    }
+
+    public static IEnumerable<object[]> Level4FalseCases()
+    {
+        yield return ["Ordinary Certificate"];
+        yield return ["Foundation Learning Award"];
+        yield return ["This contains HNCC but not the whole word"];
+        yield return ["This contains Cert HENow but not the actual phrase"];
+    }
+
+    public static IEnumerable<object[]> Level5TrueCases()
+    {
+        yield return ["Foundation Degree in Business"];
+        yield return ["Higher National Diploma in Computing"];
+        yield return ["Diploma of Higher Education in Health"];
+        yield return ["Diploma in Teaching (Further Education and Skills)"];
+        yield return ["Diploma in Teaching (FE and Skills)"];
+        yield return ["Diploma in Teaching (FE)"];
+        yield return ["Further Education and Skills Teaching Award"];
+        yield return ["Certificate in Education"];
+        yield return ["Learning and Skills Teacher qualification"];
+        yield return ["Award in HND"];
+        yield return ["Award in Dip HE"];
+        yield return ["Award in FdA"];
+        yield return ["Award in FdEng"];
+        yield return ["Award in FdSc"];
+        yield return ["Award in DiT"];
+        yield return ["Award in DIT"];
+        yield return ["Award in CertEd"];
+        yield return ["Award in CertED"];
+        yield return ["Award in LST"];
+        yield return ["ESOL International Level 5"];
+    }
+
+    public static IEnumerable<object[]> Level5FalseCases()
+    {
+        yield return ["Ordinary Diploma in Business"];
+        yield return ["Diploma in Teaching and Learning"];
+        yield return ["This contains HNDD but not the whole word"];
+        yield return ["This contains FdAcademic but not the abbreviation as a whole word"];
+        yield return ["This contains LSTX but not the whole word"];
+    }
+
+    public static IEnumerable<object[]> Level6TrueCases()
+    {
+        yield return ["Degree in Computing"];
+        yield return ["Professional Graduate Certificate in Education"];
+        yield return ["Professional Graduate Diploma in Education"];
+        yield return ["Award in BA"];
+        yield return ["Award in BSc"];
+        yield return ["Award in BEd"];
+        yield return ["Award in BEng"];
+        yield return ["Award in BTech"];
+        yield return ["Award in PgCE"];
+        yield return ["Award in PgDE"];
+        yield return ["ESOL International Level 6"];
+    }
+
+    public static IEnumerable<object[]> Level6FalseCases()
+    {
+        yield return ["Ordinary Diploma in Business"];
+        yield return ["This contains BAX but not the whole word"];
+        yield return ["Advanced Learning Certificate"];
+    }
+
+    public static IEnumerable<object[]> Level7TrueCases()
+    {
+        yield return ["Master in Finance"];
+        yield return ["Postgraduate Certificate in Education"];
+        yield return ["Postgraduate Diploma in Education"];
+        yield return ["Award in MPhil"];
+        yield return ["Award in MSc"];
+        yield return ["Award in MA"];
+        yield return ["Award in MBA"];
+        yield return ["Award in MDes"];
+        yield return ["Award in MRes"];
+        yield return ["Award in PGCE"];
+        yield return ["Award in PGDE"];
+        yield return ["ESOL International Level 7"];
+    }
+
+    public static IEnumerable<object[]> Level7FalseCases()
+    {
+        yield return ["Ordinary Diploma in Business"];
+        yield return ["This contains MAButNotAWholeWord"];
+        yield return ["This contains PGCEX but not the whole word"];
+    }
+
+    public static IEnumerable<object[]> Level8TrueCases()
+    {
+        yield return ["Doctor of Education"];
+        yield return ["Award in PhD"];
+        yield return ["Award in EngD"];
+        yield return ["ESOL International Level 8"];
+    }
+
+    public static IEnumerable<object[]> Level8FalseCases()
+    {
+        yield return ["Ordinary Diploma in Business"];
+        yield return ["This contains PhDX but not the whole word"];
+        yield return ["Advanced Research Award"];
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationTypeTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationTypeTests.cs
@@ -1,0 +1,67 @@
+﻿namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services;
+
+public class QualificationTypeTests
+{
+    [Theory]
+    [InlineData("End-Point Assessment")]
+    [InlineData("end-point assessment")]
+    [InlineData("END-POINT ASSESSMENT")]
+    [InlineData("Apprenticeship Assessment Qualification")]
+    [InlineData("apprenticeship assessment qualification")]
+    [InlineData("APPRENTICESHIP ASSESSMENT QUALIFICATION")]
+    public void IsIneligible_WhenTypeMatchesIneligibleType_ReturnsTrue(string type)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationType.IsIneligible(type);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("Some Other Type")]
+    [InlineData("End Point Assessment")]
+    [InlineData("Apprenticeship Assessment")]
+    [InlineData("End-Point Assessments")]
+    [InlineData("Apprenticeship Assessment Qualification ")]
+    [InlineData(" End-Point Assessment")]
+    public void IsIneligible_WhenTypeDoesNotExactlyMatchIneligibleType_ReturnsFalse(string? type)
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationType.IsIneligible(type);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EndPointAssessment_WhenAccessed_HasExpectedValue()
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationType.EndPointAssessment.Value;
+
+        // Assert
+        Assert.Equal("End-Point Assessment", result);
+    }
+
+    [Fact]
+    public void ApprenticeshipAssessmentQualification_WhenAccessed_HasExpectedValue()
+    {
+        // Arrange
+
+        // Act
+        var result = QualificationType.ApprenticeshipAssessmentQualification.Value;
+
+        // Assert
+        Assert.Equal("Apprenticeship Assessment Qualification", result);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.AODP.Jobs/Functions/RegulatedQualificationsDataFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/RegulatedQualificationsDataFunction.cs
@@ -72,11 +72,11 @@ namespace SFA.DAS.AODP.Functions.Functions
                     jobControl.JobRunId = await _jobConfigurationService.InsertJobRunAsync(jobControl.JobId, username, JobStatus.Running);
                 }
 
-                if (jobControl.RunApiImport)
-                {
-                    // STAGE 1 - Import Ofqual Api data to staging area
-                    totalRecords = await _ofqualImportService.ImportApiData(req);
-                }
+                //if (jobControl.RunApiImport)
+                //{
+                //    // STAGE 1 - Import Ofqual Api data to staging area
+                //    totalRecords = await _ofqualImportService.ImportApiData(req);
+                //}
 
                 if (jobControl.ProcessStagingData)
                 {

--- a/src/SFA.DAS.AODP.Jobs/Functions/RegulatedQualificationsDataFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/RegulatedQualificationsDataFunction.cs
@@ -72,11 +72,11 @@ namespace SFA.DAS.AODP.Functions.Functions
                     jobControl.JobRunId = await _jobConfigurationService.InsertJobRunAsync(jobControl.JobId, username, JobStatus.Running);
                 }
 
-                //if (jobControl.RunApiImport)
-                //{
-                //    // STAGE 1 - Import Ofqual Api data to staging area
-                //    totalRecords = await _ofqualImportService.ImportApiData(req);
-                //}
+                if (jobControl.RunApiImport)
+                {
+                    // STAGE 1 - Import Ofqual Api data to staging area
+                    totalRecords = await _ofqualImportService.ImportApiData(req);
+                }
 
                 if (jobControl.ProcessStagingData)
                 {

--- a/src/SFA.DAS.AODP.Jobs/Services/FundingEligibilityService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/FundingEligibilityService.cs
@@ -1,58 +1,23 @@
-﻿using Microsoft.Extensions.Logging;
-using SFA.DAS.AODP.Common.Enum;
-using SFA.DAS.AODP.Jobs.Interfaces;
-using SFA.DAS.AODP.Models.Qualification;
-using System.Linq;
+﻿using SFA.DAS.AODP.Models.Qualification;
 
-namespace SFA.DAS.AODP.Jobs.Services
+namespace SFA.DAS.AODP.Jobs.Services;
+
+public class FundingEligibilityService : IFundingEligibilityService
 {
-    public class FundingEligibilityService : IFundingEligibilityService
+    private readonly ILogger<FundingEligibilityService> _logger;
+
+    public FundingEligibilityService(ILogger<FundingEligibilityService> logger)
     {
-        private readonly ILogger<FundingEligibilityService> _logger;
-
-        public FundingEligibilityService(ILogger<FundingEligibilityService> logger)
-        {
-            _logger = logger;
-        }
-
-        public bool EligibleForFunding(QualificationDTO qualification)
-        {
-            var eligibleForFunding = qualification.OfferedInEngland
-                                      && (qualification.IntentionToSeekFundingInEngland ?? false)
-                                      && qualification.Type != QualificationReference.EndPointAssessment
-                                      && !QualificationReference.IneligibleQualifications.Any(s => qualification.Title.Contains(s, StringComparison.OrdinalIgnoreCase))
-                                      && !QualificationReference.IneligibleQualificationsShortForms.Any(s => qualification.Title.Contains(s, StringComparison.OrdinalIgnoreCase))
-                                      && qualification.Glh.HasValue && qualification.Tqt.HasValue
-                                      && qualification.Glh.Value > 0 && qualification.Tqt.Value > 0
-                                      && qualification.Glh < qualification.Tqt;
-
-            if (eligibleForFunding)
-            {
-                _logger.LogInformation($"[{nameof(FundingEligibilityService)}] -> [{nameof(EligibleForFunding)}] -> Qualification {qualification.QualificationNumberNoObliques} eligible for funding");
-            }
-            else
-            {
-                _logger.LogInformation($"[{nameof(FundingEligibilityService)}] -> [{nameof(EligibleForFunding)}] -> Qualification {qualification.QualificationNumberNoObliques} NOT eligible for funding");
-            }
-
-            return eligibleForFunding;
-        }
-
-        public string DetermineFailureReason(QualificationDTO qualification)
-        {
-            var reason = ImportReason.NoAction;
-
-            var noGlhOrTqt = !qualification.Glh.HasValue 
-                            || !qualification.Tqt.HasValue
-                            || (qualification.Glh.Value <= 0 && qualification.Tqt.Value <= 0);
-
-            if (noGlhOrTqt)
-            {
-                _logger.LogInformation($"[{nameof(FundingEligibilityService)}] -> [{nameof(EligibleForFunding)}] -> Qualification {qualification.QualificationNumberNoObliques} has no GLH/TQT");
-                reason = ImportReason.NoGLHOrTQT;
-            }            
-
-            return reason;
-        }
+        _logger = logger;
     }
+
+    public bool EligibleForFunding(QualificationDTO qualification)
+    {
+        return qualification.OfferedInEngland
+               && (qualification.IntentionToSeekFundingInEngland ?? false)
+               && !QualificationReference.IsIneligibleType(qualification.Type)
+               && !QualificationReference.HasIneligibleTitle(qualification.Level, qualification.Title);
+    }
+
+    public string DetermineFailureReason(QualificationDTO qualification) => ImportReason.NoAction;
 }

--- a/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
@@ -120,7 +120,7 @@ namespace SFA.DAS.AODP.Jobs.Services
         {
             _logger.LogInformation($"[{nameof(OfqualImportService)}] -> [{nameof(ProcessQualificationsDataAsync)}] -> Processing Ofqual Qualifications Staging Data...");
 
-            const int batchSize = 500;
+            const int batchSize = 1000;
             int processedCount = 0;
             _processStopWatch.Restart();
 

--- a/src/SFA.DAS.AODP.Jobs/Services/QualificationsService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/QualificationsService.cs
@@ -69,6 +69,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                 _logger.LogInformation($"[{nameof(QualificationsService)}] -> [{nameof(GetStagedQualificationsBatchAsync)}] -> Retrieving next batch of {batchSize} staged qualifications from record {processedCount}...");
 
                 var stagedQualifications = await _applicationDbContext.QualificationImportStaging
+                    .AsNoTracking()
                     .OrderBy(q => q.Id)
                     .Skip(processedCount)
                     .Take(batchSize)


### PR DESCRIPTION
[AWARD-1178]

- Removed GLH and TQT rules for eligibility due to issues with GCSEs and A Levels amongst others, not appearing in QFAST due to incorrect logic
- Refined qualification title check to be applied alongside the qualification level so all but ESOL International only apply at certain levels, i.e. a qualification title that contains 'Certificate in Education' only applies IF the qualification level is Level 5
- Fixed type in qualification type ineligibility list and included Apprenticeship Assessment Qualification which was previously missing
- Removed excessive logging that slowed down the regulated import substantially

[AWARD-1178]: https://skillsfundingagency.atlassian.net/browse/AWARD-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ