### PR TITLE
[AWARD-1184] - Changed funded import to note over write notes

### DIFF
--- a/src/SFA.DAS.AODP.Data/Entities/QualificationFunding.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/QualificationFunding.cs
@@ -14,5 +14,16 @@ namespace SFA.DAS.AODP.Data.Entities
 
         public virtual QualificationVersions QualificationVersion { get; set; }
         public virtual FundingOffer FundingOffer { get; set; }
+
+        public static QualificationFunding Create(Guid qualificationVersionId, Guid fundingOfferId, DateOnly? startDate, DateOnly? endDate, string? comments) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                QualificationVersionId = qualificationVersionId,
+                FundingOfferId = fundingOfferId,
+                StartDate = startDate,
+                EndDate = endDate,
+                Comments = comments
+            };
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
@@ -25,8 +25,12 @@ namespace SFA.DAS.AODP.Infrastructure.Services
 
             try
             {
-                const int _batchSize = 1000;
+                const int _batchSize = 2000;
+                
                 _logger.LogInformation("Writing funded qualifications to db");
+
+                _applicationDbContext.StartingBulkInsert();
+
                 for (var i = 0; i < qualifications.Count; i += _batchSize)
                 {
                     var batch = qualifications
@@ -63,6 +67,8 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                 }
 
                 await _applicationDbContext.SaveChangesAsync();
+
+                _applicationDbContext.FinishedBulkInsert();
             }
             catch (Exception ex)
             {
@@ -79,25 +85,29 @@ namespace SFA.DAS.AODP.Infrastructure.Services
 
             try
             {
+                _applicationDbContext.StartingBulkInsert();
+                
                 var offerTypeLookup = await _applicationDbContext.FundingOffers.AsNoTracking().ToDictionaryAsync(r => r.Name, r => r.Id);
                 var actionLookup = await _applicationDbContext.ActionType.AsNoTracking().ToDictionaryAsync(r => r.Description ?? "", r => r.Id);
                 var noActionNeededId = actionLookup[ActionTypeEnum.NoActionRequired];
 
                 // Funding offers from imported data
                 var importedOffers = await _applicationDbContext.FundedQualifications
-                                        .Include(i => i.QualificationOffers)
-                                        .Where(w => w.QualificationId.HasValue
-                                                && w.AwardingOrganisationId.HasValue
-                                                && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
-                                        .ToListAsync();
-                var importedOfferIds = importedOffers.Select(s => s.QualificationId.Value).ToList();
+                    .Include(i => i.QualificationOffers)
+                    .Where(w => w.QualificationId.HasValue
+                                && w.AwardingOrganisationId.HasValue
+                                && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
+                    .ToListAsync();
+
+                var importedOfferIds = importedOffers.Select(s => s.QualificationId!.Value).ToList();
 
                 // Funding offers created by users
                 var userCreatedOffers = await _applicationDbContext.QualificationFundings
-                                        .Include(i => i.FundingOffer)
-                                        .Include(i => i.QualificationVersion)
-                                        .ThenInclude(t => t.Qualification)
-                                        .ToListAsync();
+                    .Include(i => i.FundingOffer)
+                    .Include(i => i.QualificationVersion)
+                    .ThenInclude(t => t.Qualification)
+                    .ToListAsync();
+
                 var userCreatedOfferIds = userCreatedOffers.Select(s => s.QualificationVersion.QualificationId).ToList();
 
                 // Previously, only records with qualifications offering feedback that were not approved were updated.
@@ -131,10 +141,11 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                         .Where(w => qualsMissingFunding.Contains(w.QualificationId))                                                    
                         .ToListAsync();
 
-                    var batchSize = 1000;
+                    var batchSize = 2000;
                     var batchCounter = 0;
                     var newRecords = new List<QualificationFunding>();
                     var newDiscussions = new List<QualificationDiscussionHistory>();
+
 
                     foreach (var id in qualsMissingFunding)
                     {
@@ -189,7 +200,7 @@ namespace SFA.DAS.AODP.Infrastructure.Services
 
                             if (added > 0)
                             {
-                                _logger.LogInformation($"Found {added} missing offers for {latestVersion.Name}");                               
+                                _logger.LogDebug("Found {AddedCount} missing offers for {LatestVersionName}", added, latestVersion.Name);                               
 
                                 newDiscussions.Add(new QualificationDiscussionHistory()
                                 {
@@ -234,7 +245,7 @@ namespace SFA.DAS.AODP.Infrastructure.Services
 
                 if (qualsNeedUpdating.Any())
                 {
-                    var batchSize = 1000;
+                    var batchSize = 2000;
                     var batchCounter = 0;
                     var newOffers = new List<QualificationFunding>();
                     var updatedOffers = new List<QualificationFunding>();
@@ -363,6 +374,8 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                         batchCounter = 0;
                     }
                 }
+
+                _applicationDbContext.FinishedBulkInsert();
             }
             catch (Exception ex)
             {

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Services/FundedQualificationWriter.cs
@@ -27,7 +27,7 @@ namespace SFA.DAS.AODP.Infrastructure.Services
             {
                 const int _batchSize = 1000;
                 _logger.LogInformation("Writing funded qualifications to db");
-                for (int i = 0; i < qualifications.Count; i += _batchSize)
+                for (var i = 0; i < qualifications.Count; i += _batchSize)
                 {
                     var batch = qualifications
                         .Skip(i)
@@ -79,8 +79,8 @@ namespace SFA.DAS.AODP.Infrastructure.Services
 
             try
             {
-                var offerTypeLookup = await _applicationDbContext.FundingOffers.ToDictionaryAsync(r => r.Name, r => r.Id);
-                var actionLookup = await _applicationDbContext.ActionType.ToDictionaryAsync(r => r.Description ?? "", r => r.Id);
+                var offerTypeLookup = await _applicationDbContext.FundingOffers.AsNoTracking().ToDictionaryAsync(r => r.Name, r => r.Id);
+                var actionLookup = await _applicationDbContext.ActionType.AsNoTracking().ToDictionaryAsync(r => r.Description ?? "", r => r.Id);
                 var noActionNeededId = actionLookup[ActionTypeEnum.NoActionRequired];
 
                 // Funding offers from imported data
@@ -126,9 +126,10 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                 {
                     _logger.LogInformation($"SeedFundingData -> Adding missing offers to funded.QualificationFundings");
 
-                    var missingQualLookup = await _applicationDbContext.QualificationVersions                                                    
-                                                    .Where(w => qualsMissingFunding.Contains(w.QualificationId))                                                    
-                                                    .ToListAsync();
+                    var missingQualLookup = await _applicationDbContext.QualificationVersions
+                        .AsNoTracking()
+                        .Where(w => qualsMissingFunding.Contains(w.QualificationId))                                                    
+                        .ToListAsync();
 
                     var batchSize = 1000;
                     var batchCounter = 0;
@@ -139,9 +140,9 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                     {
                         // Exists in FundedQualifications, Create new QualificationFunding record
                         var latestVersion = missingQualLookup
-                                                .Where(w => w.QualificationId == id)
-                                                .OrderByDescending(o => o.Version)
-                                                .FirstOrDefault();
+                            .Where(w => w.QualificationId == id)
+                            .OrderByDescending(o => o.Version)
+                            .FirstOrDefault();
 
                         if (latestVersion == null)
                         {
@@ -150,14 +151,14 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                         }
 
                         var fundedQualToBeAdded = importedOffers
-                                                    .Where(w => w.QualificationId == id && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
-                                                    .FirstOrDefault();
+                            .Where(w => w.QualificationId == id && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
+                            .FirstOrDefault();
 
                         if (fundedQualToBeAdded != null)
                         {
                             var offers = fundedQualToBeAdded.QualificationOffers.Where(w => w.FundingAvailable ?? false).ToList();
                             
-                            int added = 0;
+                            var added = 0;
                             foreach (var offer in offers)
                             {
                                 if (offerTypeLookup.ContainsKey(offer.Name))
@@ -174,15 +175,13 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                                         endDate = new DateOnly(offer.FundingApprovalEndDate.Value.Year, offer.FundingApprovalEndDate.Value.Month, offer.FundingApprovalEndDate.Value.Day);
                                     }
 
-                                    var newRecord = new QualificationFunding()
-                                    {
-                                        Id = Guid.NewGuid(),
-                                        QualificationVersionId = latestVersion.Id,
-                                        FundingOfferId = offerTypeId,
-                                        StartDate = startDate,
-                                        EndDate = endDate,
-                                        Comments = $"Imported from Funded CSV on {importRun.ToShortDateString()}"
-                                    };
+                                    var newRecord = QualificationFunding.Create(
+                                        latestVersion.Id, 
+                                        offerTypeId,
+                                        startDate, 
+                                        endDate, 
+                                        offer.Notes);
+
                                     newRecords.Add(newRecord);
                                     added++;
                                 }
@@ -241,17 +240,19 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                     var updatedOffers = new List<QualificationFunding>();
                     var newDiscussions = new List<QualificationDiscussionHistory>();
 
-                    var updatingQualLookup = await _applicationDbContext.QualificationVersions                                                    
-                                                    .Where(w => qualsNeedUpdating.Contains(w.QualificationId))
-                                                    .ToListAsync();
+                    var updatingQualLookup = await _applicationDbContext.QualificationVersions
+                        .AsNoTracking()
+                        .Where(w => qualsNeedUpdating.Contains(w.QualificationId))
+                        .ToListAsync();
 
                     foreach (var id in qualsNeedUpdating)
                     {
-                        
+
                         var latestVersion = updatingQualLookup
-                                                    .Where(w => w.QualificationId == id)
-                                                    .OrderByDescending(o => o.Version)
-                                                    .FirstOrDefault();
+                            .Where(w => w.QualificationId == id)
+                            .OrderByDescending(o => o.Version)
+                            .FirstOrDefault();
+
                         if (latestVersion == null)
                         {
                             _logger.LogError($"SeedFundingData -> Unable to process Qual Id {id} as it has no qualification versions");
@@ -259,15 +260,16 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                         }
 
                         var importedOfferToBeUpdated = importedOffers
-                                                    .Where(w => w.QualificationId == id && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
-                                                    .FirstOrDefault();
+                            .Where(w => w.QualificationId == id && w.QualificationOffers.Any(a => a.FundingAvailable ?? false))
+                            .FirstOrDefault();
+
                         if (importedOfferToBeUpdated != null)
                         {
-                            
                             var existingUserOffers = userCreatedOffers.Where(w => w.QualificationVersion.QualificationId == id).ToList();
                             var offers = importedOfferToBeUpdated.QualificationOffers.Where(w => w.FundingAvailable ?? false).ToList();
-                            int added = 0;
-                            int updated = 0;
+                            var added = 0;
+                            var updated = 0;
+
                             foreach (var offer in offers)
                             {
                                 if (offerTypeLookup.ContainsKey(offer.Name))
@@ -301,20 +303,20 @@ namespace SFA.DAS.AODP.Infrastructure.Services
                                     else
                                     {
                                         // create missing offer
-                                        var newRecord = new QualificationFunding()
-                                        {
-                                            Id = Guid.NewGuid(),
-                                            QualificationVersionId = latestVersion.Id,
-                                            FundingOfferId = offerTypeId,
-                                            StartDate = startDate,
-                                            EndDate = endDate,
-                                            Comments = $"Imported from Funded CSV on {importRun.ToShortDateString()}"
-                                        };
+                                        var newRecord = QualificationFunding.Create(
+                                            latestVersion.Id,
+                                            offerTypeId,
+                                            startDate,
+                                            endDate,
+                                            offer.Notes
+                                        );
+
                                         newOffers.Add(newRecord);
                                         added++;
                                     }
                                 }
                             }
+
                             if ((added + updated) > 0)
                             {
                                 _logger.LogInformation($"Added {added} and updated {updated} offers for {latestVersion.Name}");                             

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationWriterTests.cs
@@ -213,8 +213,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var writeResult = await _service.WriteQualifications(importedData);
             
             Assert.True(writeResult);
-            var insertedOffers = await _dbContext.QualificationOffers
-                                    .ToListAsync();
+            var insertedOffers = await _dbContext.QualificationOffers.ToListAsync();
             Assert.Equal(sets.Count, insertedOffers.Count);
 
             var seedResult = await _service.SeedFundingData();
@@ -222,17 +221,21 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             //Assert
             Assert.True(seedResult);
             var insertedFundings = await _dbContext.QualificationFundings
-                                        .Include(i => i.QualificationVersion)
-                                            .ThenInclude(t => t.Qualification)
-                                        .Include(i => i.FundingOffer)
-                                        .ToListAsync();
+                .Include(i => i.QualificationVersion)
+                .ThenInclude(t => t.Qualification)
+                .Include(i => i.FundingOffer)
+                .ToListAsync();
+
             Assert.Equal(6, insertedFundings.Count);
-            var matchingFunding = insertedFundings.Where(w => w.QualificationVersion.QualificationId == insertedOffers[0].Qualification.QualificationId
-                                                            && w.FundingOffer.Name == insertedOffers[0].Name).FirstOrDefault();
+            var matchingFunding = insertedFundings.FirstOrDefault(w =>
+                w.QualificationVersion.QualificationId == insertedOffers[0].Qualification!.QualificationId
+                && w.FundingOffer.Name == insertedOffers[0].Name);
+
             Assert.NotNull(matchingFunding);
             Assert.Equal(insertedOffers[0].Name, matchingFunding.FundingOffer.Name);
             Assert.Equal(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalStartDate.Value), matchingFunding.StartDate);
             Assert.Equal(DateOnly.FromDateTime(insertedOffers[0].FundingApprovalEndDate.Value), matchingFunding.EndDate);
+            Assert.StartsWith("18+ only", insertedOffers[0].Notes);
         }
 
         //[Fact]
@@ -292,6 +295,8 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                 var offer = _fixture.Create<FundedQualificationOfferDTO>();
                 offer.QualificationId = set.QualId;
                 offer.FundingAvailable = fundingAvailable.ToString();
+                offer.Notes = "18+ only";
+
                 var importRecord = _fixture.Build<FundedQualificationDTO>()
                                     .With(w => w.AwardingOrganisationId, set.OrgId)
                                     .With(w => w.Id, Guid.NewGuid())

--- a/src/SFA.DAS.AODP.Jobs.Test/Entities/QualificationFundingTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Entities/QualificationFundingTests.cs
@@ -1,0 +1,24 @@
+﻿namespace SFA.DAS.AODP.Jobs.UnitTests.Entities;
+
+public class QualificationFundingTests : UnitTest
+{
+    [Fact]
+    public void QualificationFunding_Create_EnsureCreatedCorrectly()
+    {
+        // Arrange
+        var qualificationVersion = Guid.NewGuid();
+        var fundingOfferId = Guid.NewGuid();
+        var startDate = new DateOnly(2025, 01, 20);
+        var endDate = new DateOnly(2027, 01, 20);
+
+        // Act
+        var qualificationFunding = QualificationFunding.Create(qualificationVersion, fundingOfferId, startDate, endDate, "comments");
+
+        // Assert
+        Assert.Equal(qualificationVersion, qualificationFunding.QualificationVersionId);
+        Assert.Equal(fundingOfferId, qualificationFunding.FundingOfferId);
+        Assert.Equal(startDate, qualificationFunding.StartDate);
+        Assert.Equal(endDate, qualificationFunding.EndDate);
+        Assert.Equal("comments", qualificationFunding.Comments);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Entities/RegulatedQaaQualificationTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Entities/RegulatedQaaQualificationTests.cs
@@ -1,6 +1,6 @@
 namespace SFA.DAS.AODP.Jobs.UnitTests.Entities;
 
-public class RegulatedQaaQualificationTests
+public class RegulatedQaaQualificationTests : UnitTest
 {
     private const string TestAimCode = "Z1234567";
     private const string TestQualificationTitle = "Access to Higher Education Diploma (Science)";

--- a/src/SFA.DAS.AODP.Jobs.Test/GlobalUsings.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using SFA.DAS.AODP.Jobs.Functions;
 global using SFA.DAS.AODP.Jobs.Interfaces;
 global using SFA.DAS.AODP.Jobs.Models.Jobs;
 global using SFA.DAS.AODP.Jobs.Services;
+global using SFA.DAS.AODP.Jobs.UnitTests.Testing;
 global using SFA.DAS.AODP.Models.QaaQualification;
 global using SFA.DAS.Funding.ApprenticeshipEarnings.Domain.Services;
 

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+	<NoWarn>xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.AODP.Jobs.Test/Testing/UnitTest.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Testing/UnitTest.cs
@@ -1,0 +1,17 @@
+﻿namespace SFA.DAS.AODP.Jobs.UnitTests.Testing;
+
+/// <summary>
+/// Base class for all tests in this project to provide common functionality and context for the tests.
+/// </summary>
+public class UnitTest
+{
+    /// <summary>
+    /// Provides a context object for the currently executing test, allowing access to test-specific information such as test name, test properties, and more.
+    /// </summary>
+    protected ITestContext CurrentContext => TestContext.Current;
+
+    /// <summary>
+    /// Provides access to a <see cref="CancellationToken"/> from the <see cref="TestContext"/>
+    /// </summary>
+    protected CancellationToken CancellationToken => CurrentContext.CancellationToken;
+}

--- a/src/SFA.DAS.AODP.Jobs/Program.cs
+++ b/src/SFA.DAS.AODP.Jobs/Program.cs
@@ -17,7 +17,10 @@ public class Program
             builder.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Warning);
             builder.AddFilter(typeof(Program).Namespace, LogLevel.Information);
             builder.SetMinimumLevel(LogLevel.Information);
+
+#if DEBUG
             builder.AddConsole();
+#endif
         });
 
         builder.Services

--- a/src/SFA.DAS.AODP.Jobs/Program.cs
+++ b/src/SFA.DAS.AODP.Jobs/Program.cs
@@ -16,13 +16,8 @@ public class Program
             builder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft", LogLevel.Information);
             builder.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Warning);
             builder.AddFilter(typeof(Program).Namespace, LogLevel.Information);
-
-#if DEBUG
-            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.SetMinimumLevel(LogLevel.Information);
             builder.AddConsole();
-#else
-    builder.SetMinimumLevel(LogLevel.Information);
-#endif
         });
 
         builder.Services


### PR DESCRIPTION
[AWARD-1184]

- The funded file import was not taking the funding notes from the files and applying them to the funded.QualificationFundings correctly. Instead it was over writing it with an internal note.
- This PR fixes that such that copies over the Note column from funded.QualificationOffers -> funded.QualificationFundings Comments column

[AWARD-1184]: https://skillsfundingagency.atlassian.net/browse/AWARD-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ