### PR TITLE
[AWARD-1200] - Fix issue with incorrect date formats

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
[AWARD-1200]

- When the funded file import runs it was incorrectly setting the date formats to yyyy-mm-dd and this was due to the culture settings, in azure function apps its sets en-US meaning it uses American format, so the fix for now is to set the global culture in the code base to ensure its set to en-GB and uses the correct formatting. Long term we need a better more consistent approach to manage date formats and use the invariant culture

[AWARD-1200]: https://skillsfundingagency.atlassian.net/browse/AWARD-1200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ