### PR TITLE
[AWARD-1199] Funded import no longer relies on org name from funded file

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/IQualificationVersionRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/IQualificationVersionRepository.cs
@@ -1,0 +1,9 @@
+﻿using static SFA.DAS.AODP.Infrastructure.Repositories.QualificationVersionRepository;
+
+namespace SFA.DAS.AODP.Infrastructure.Interfaces
+{
+    public interface IQualificationVersionRepository
+    {
+        Task<List<QualificationLookupItem>> GetLatestQualificationVersionSnapshotsAsync();
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/QualificationVersionRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/QualificationVersionRepository.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.AODP.Infrastructure.Context;
+using SFA.DAS.AODP.Infrastructure.Interfaces;
+
+namespace SFA.DAS.AODP.Infrastructure.Repositories
+{
+    public class QualificationVersionRepository : IQualificationVersionRepository
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ILogger<QualificationVersionRepository> _logger;
+
+        public QualificationVersionRepository(IApplicationDbContext context, ILogger<QualificationVersionRepository> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<List<QualificationLookupItem>> GetLatestQualificationVersionSnapshotsAsync()
+        {
+            var data = await _context.QualificationVersions
+                .AsNoTracking()
+                .Include(v => v.Qualification)
+                .ToListAsync();
+
+            return data
+                .GroupBy(v => v.QualificationId)
+                .Select(g =>
+                    g.OrderByDescending(v => v.Version).First())
+                .Select(v => new QualificationLookupItem(
+                    v.Qualification.Qan,
+                    v.QualificationId,
+                    v.AwardingOrganisationId))
+                .ToList();
+        }
+
+        public sealed record QualificationLookupItem(
+            string Qan,
+            Guid? QualificationId,
+            Guid? AwardingOrganisationId
+        );
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/FundedQualificationsDataFunctionTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/FundedQualificationsDataFunctionTests.cs
@@ -2,30 +2,25 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using SFA.DAS.AODP.Common.Enum;
-using SFA.DAS.AODP.Data.Entities;
 using SFA.DAS.AODP.Functions;
 using SFA.DAS.AODP.Infrastructure.Context;
 using SFA.DAS.AODP.Infrastructure.Interfaces;
-using SFA.DAS.AODP.Jobs.Interfaces;
-using SFA.DAS.AODP.Jobs.Services;
 using SFA.DAS.AODP.Jobs.Services.CSV;
 using SFA.DAS.AODP.Jobs.Test.Mocks;
 using SFA.DAS.AODP.Models.Config;
 using SFA.DAS.AODP.Models.Qualification;
+using static SFA.DAS.AODP.Infrastructure.Repositories.QualificationVersionRepository;
 
 namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
 {
     public class FundedQualificationsDataFunctionTests
     {
         private readonly Mock<ILogger<FundedQualificationsDataFunction>> _loggerMock;
-        private readonly Mock<IApplicationDbContext> _applicationDbContextMock;
         private readonly Mock<ICsvReaderService> _csvReaderServiceMock;
         private readonly Mock<IJobConfigurationService> _jobConfigurationService;
         private readonly Mock<IFundedQualificationWriter> _fundedQualificationWriter;
         private readonly Mock<IQualificationsRepository> _qualificationsRepository;
+        private readonly Mock<IQualificationVersionRepository> _qualificationVersionRepository;
         private readonly FunctionContext _functionContext;
         private readonly FundedQualificationsDataFunction _function;
         private readonly AodpJobsConfiguration _config;
@@ -66,6 +61,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
             _jobConfigurationService.Setup(s => s.GetLastJobRunAsync(JobNames.FundedQualifications.ToString())).ReturnsAsync(_jobRunControl);
             _fundedQualificationWriter = new Mock<IFundedQualificationWriter>();
             _qualificationsRepository = new Mock<IQualificationsRepository>();
+            _qualificationVersionRepository = new Mock<IQualificationVersionRepository>();
 
             _function = new FundedQualificationsDataFunction(
                 _loggerMock.Object,               
@@ -73,18 +69,15 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
                 _config,
                 _jobConfigurationService.Object,
                 _fundedQualificationWriter.Object,
-                _qualificationsRepository.Object);
+                _qualificationsRepository.Object,
+                _qualificationVersionRepository.Object);
         }
 
         [Fact]
         public async Task Run_ShouldReturnOk()
         {
             // Arrange
-            var organisations = _fixture.Build<AwardingOrganisation>()
-                .CreateMany(5)
-                .ToList();
-
-            var qualifications = _fixture.Build<Qualification>()
+            var qualificationLookups = _fixture.Build<QualificationLookupItem>()
                 .CreateMany(20)
                 .ToList();
 
@@ -97,14 +90,13 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
                 .ToList();
 
             _csvReaderServiceMock                                                                                             
-                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualifications, organisations, It.IsAny<ILogger>()))
+                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualificationLookups, It.IsAny<ILogger>()))
                 .ReturnsAsync(fundedImport);
             _csvReaderServiceMock
-                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.ArchivedFundedQualificationsImportUrl, qualifications, organisations, It.IsAny<ILogger>()))
+                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.ArchivedFundedQualificationsImportUrl, qualificationLookups, It.IsAny<ILogger>()))
                 .ReturnsAsync(archivedImport);
 
-            _qualificationsRepository.Setup(s => s.GetAwardingOrganisationsAsync()).ReturnsAsync(organisations).Verifiable();
-            _qualificationsRepository.Setup(s => s.GetQualificationsAsync()).ReturnsAsync(qualifications).Verifiable();
+            _qualificationVersionRepository.Setup(s => s.GetLatestQualificationVersionSnapshotsAsync()).ReturnsAsync(qualificationLookups).Verifiable();
             _qualificationsRepository.Setup(s => s.TruncateFundingTables()).Verifiable(Times.Once);
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(fundedImport)).ReturnsAsync(true).Verifiable();
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(archivedImport)).ReturnsAsync(true).Verifiable();
@@ -124,15 +116,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
         [Fact]
         public async Task Run_ShouldReturnNotFound_WhenCsvFileIsNotFound()
         {
-            var organisations = _fixture.Build<AwardingOrganisation>()
-                .CreateMany(5)
-                .ToList();
-
-            var qualifications = _fixture.Build<Qualification>()
-                .CreateMany(20)
-                .ToList();
-
-            var fundedImport = _fixture.Build<FundedQualificationDTO>()
+            var qualificationLookups = _fixture.Build<QualificationLookupItem>()
                 .CreateMany(20)
                 .ToList();
 
@@ -140,8 +124,12 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
                 .CreateMany(10)
                 .ToList();
 
-            _qualificationsRepository.Setup(s => s.GetAwardingOrganisationsAsync()).ReturnsAsync(organisations).Verifiable();
-            _qualificationsRepository.Setup(s => s.GetQualificationsAsync()).ReturnsAsync(qualifications).Verifiable();
+            var fundedImport = _fixture.Build<FundedQualificationDTO>()
+                .CreateMany(20)
+                .ToList();
+
+
+            _qualificationVersionRepository.Setup(s => s.GetLatestQualificationVersionSnapshotsAsync()).ReturnsAsync(qualificationLookups).Verifiable();
             _qualificationsRepository.Setup(s => s.TruncateFundingTables()).Verifiable(Times.Once);
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(fundedImport)).ReturnsAsync(true).Verifiable();
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(archivedImport)).ReturnsAsync(true).Verifiable();
@@ -149,7 +137,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
 
             // Arrange
             _csvReaderServiceMock
-                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualifications, organisations, It.IsAny<ILogger>()))
+                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualificationLookups, It.IsAny<ILogger>()))
                 .ReturnsAsync(new List<FundedQualificationDTO>());
 
             var httpRequestData = new MockHttpRequestData(_functionContext);          
@@ -164,11 +152,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
         [Fact]
         public async Task Run_ShouldStatusCode_WhenException()
         {
-            var organisations = _fixture.Build<AwardingOrganisation>()
-                .CreateMany(5)
-                .ToList();
-
-            var qualifications = _fixture.Build<Qualification>()
+            var qualificationLookups = _fixture.Build<QualificationLookupItem>()
                 .CreateMany(20)
                 .ToList();
 
@@ -180,8 +164,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
                 .CreateMany(10)
                 .ToList();
 
-            _qualificationsRepository.Setup(s => s.GetAwardingOrganisationsAsync()).ReturnsAsync(organisations).Verifiable();
-            _qualificationsRepository.Setup(s => s.GetQualificationsAsync()).ReturnsAsync(qualifications).Verifiable();
+            _qualificationVersionRepository.Setup(s => s.GetLatestQualificationVersionSnapshotsAsync()).ReturnsAsync(qualificationLookups).Verifiable();
             _qualificationsRepository.Setup(s => s.TruncateFundingTables()).Verifiable(Times.Once);
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(fundedImport)).ReturnsAsync(true).Verifiable();
             _fundedQualificationWriter.Setup(s => s.WriteQualifications(archivedImport)).ReturnsAsync(true).Verifiable();
@@ -189,7 +172,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Functions
 
             // Arrange
             _csvReaderServiceMock
-                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualifications, organisations, It.IsAny<ILogger>()));
+                .Setup(service => service.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(_config.FundedQualificationsImportUrl, qualificationLookups, It.IsAny<ILogger>()));
 
             var httpRequestData = new MockHttpRequestData(_functionContext);
 

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationsImportClassMapTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/FundedQualificationsImportClassMapTests.cs
@@ -1,0 +1,213 @@
+﻿using CsvHelper;
+using CsvHelper.Configuration;
+using SFA.DAS.AODP.Jobs.Services.CSV;
+using SFA.DAS.AODP.Models.Qualification;
+using System.Globalization;
+using static SFA.DAS.AODP.Infrastructure.Repositories.QualificationVersionRepository;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services
+{
+    public class FundedQualificationsImportClassMapTests
+    {
+        private static List<FundedQualificationDTO> ParseCsv(
+            string csv,
+            List<string> headers,
+            List<QualificationLookupItem> lookup,
+            ILogger logger)
+        {
+            using var reader = new StringReader(csv);
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+            {
+                HeaderValidated = null,
+                MissingFieldFound = null
+            };
+
+            using var csvReader = new CsvReader(reader, config);
+
+
+            csvReader.Context.RegisterClassMap(
+                new FundedQualificationsImportClassMap(headers, lookup, logger));
+
+            return csvReader.GetRecords<FundedQualificationDTO>().ToList();
+        }
+
+
+        [Fact]
+        public void Should_Map_Qualification_And_Organisation_From_Lookup()
+        {
+            var logger = Mock.Of<ILogger>();
+
+            var qId = Guid.NewGuid();
+            var orgId = Guid.NewGuid();
+
+            var lookup = new List<QualificationLookupItem>
+            {
+                new("Q1", qId, orgId)
+            };
+
+            var csv = @"QualificationNumber
+
+Q1";
+
+            var result = ParseCsv(csv, new List<string>(), lookup, logger);
+
+            var item = result.Single();
+
+            Assert.Equal(qId, item.QualificationId);
+            Assert.Equal(orgId, item.AwardingOrganisationId);
+        }
+
+        [Fact]
+        public void Should_Return_Null_When_QAN_Not_In_Lookup()
+        {
+            var logger = Mock.Of<ILogger>();
+
+            var lookup = new List<QualificationLookupItem>();
+
+            var csv = @"QualificationNumber
+Q1";
+
+            var result = ParseCsv(csv, new List<string>(), lookup, logger);
+
+            var item = result.Single();
+
+            Assert.Null(item.QualificationId);
+            Assert.Null(item.AwardingOrganisationId);
+        }
+
+        [Fact]
+        public void Should_Log_Warning_And_Return_Default_When_QAN_Empty()
+        {
+            var loggerMock = new Mock<ILogger>();
+
+            var lookup = new List<QualificationLookupItem>
+            {
+                new("Q1", Guid.NewGuid(), Guid.NewGuid())
+            };
+
+            var csv = @"QualificationNumber
+";
+
+            var result = ParseCsv(csv, new List<string>(), lookup, loggerMock.Object);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Should_Create_Offers_From_Headers()
+        {
+            var logger = Mock.Of<ILogger>();
+
+            var qId = Guid.NewGuid();
+
+            var lookup = new List<QualificationLookupItem>
+            {
+                new("Q1", qId, Guid.NewGuid() )
+            };
+
+            var headers = new List<string>
+            {
+                "OfferA"
+            };
+
+            var csv = @"QualificationNumber,OfferA_FundingApprovalStartDate,OfferA_FundingApprovalEndDate,OfferA_Notes,OfferA_FundingAvailable
+Q1,01/01/2024,01/01/2025,Note1,Yes";
+
+            var result = ParseCsv(csv, headers, lookup, logger);
+
+            var item = result.Single();
+
+            Assert.Single(item.Offers);
+
+            var offer = item.Offers.First();
+
+            Assert.Equal("OfferA", offer.Name);
+            Assert.Equal("Note1", offer.Notes);
+            Assert.Equal("Yes", offer.FundingAvailable);
+        }
+
+        [Fact]
+        public void Should_Null_Invalid_Or_Too_Early_Dates()
+        {
+            var logger = Mock.Of<ILogger>();
+
+            var qId = Guid.NewGuid();
+
+            var lookup = new List<QualificationLookupItem>
+            {
+                new("Q1", qId, Guid.NewGuid())
+            };
+
+            var headers = new List<string>
+            {
+                "OfferA"
+            };
+
+            var csv = @"QualificationNumber,OfferA_FundingApprovalStartDate,OfferA_FundingApprovalEndDate,OfferA_Notes,OfferA_FundingAvailable
+Q1,01/01/1700,not-a-date,Note1,Yes";
+
+            var result = ParseCsv(csv, headers, lookup, logger);
+
+            var offer = result.Single().Offers.Single();
+
+            Assert.Null(offer.FundingApprovalStartDate);
+            Assert.Null(offer.FundingApprovalEndDate);
+        }
+
+        [Fact]
+        public void Should_Log_Warning_When_QAN_Missing_For_Offers()
+        {
+            var loggerMock = new Mock<ILogger>();
+
+            var lookup = new List<QualificationLookupItem>();
+
+            var headers = new List<string>
+            {
+                "OfferA_FundingApprovalStartDate"
+            };
+
+            var csv = @"QualificationNumber,OfferA_FundingApprovalStartDate
+,01/01/2024";
+
+            ParseCsv(csv, headers, lookup, loggerMock.Object);
+
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Empty qualification number")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void Should_Return_No_Offers_When_QualificationId_Is_Null()
+        {
+            var logger = Mock.Of<ILogger>();
+
+            var lookup = new List<QualificationLookupItem>
+            {
+                new("Q1", null,Guid.NewGuid())
+            };
+
+            var headers = new List<string>
+            {
+                "OfferA_FundingApprovalStartDate",
+                "OfferA_FundingApprovalEndDate",
+                "OfferA_Notes",
+                "OfferA_FundingAvailable"
+            };
+
+            var csv = @"QualificationNumber,OfferA_FundingApprovalStartDate
+Q1,01/01/2024";
+
+            var result = ParseCsv(csv, headers, lookup, logger);
+
+            var item = result.Single();
+
+            Assert.Empty(item.Offers);
+        }
+
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
@@ -915,6 +915,249 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             Assert.Empty(feedbacks);         
         }
 
+        [Fact]
+        public async Task OfqualImportService_Should_Update_AwardingOrganisation_When_Details_Change()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+            var qan = "qan1";
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                qan,
+                "Qual1",
+                ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, qan, "Qual1");
+
+            // simulate change in organisation fields
+            importRecord.OrganisationName = "Updated Name";
+            importRecord.OrganisationAcronym = "NEW";
+            importRecord.OrganisationRecognitionNumber = "RN-999";
+
+            var importRecords = new List<QualificationDTO> { importRecord };
+
+            ApplyMockBehaviour(
+                importRecord,
+                importRecords,
+                eligibleForFunding: false,
+                changesPresent: true,
+                keyFieldsChanged: true);
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert
+            var org = await _dbContext.AwardingOrganisation
+                .SingleAsync(x => x.Ukprn == organisationId);
+
+            Assert.Equal("Updated Name", org.NameOfqual);
+            Assert.Equal("NEW", org.Acronym);
+            Assert.Equal("RN-999", org.RecognitionNumber);
+        }
+
+
+
+        [Fact]
+        public async Task OfqualImportService_Should_Not_Create_Duplicate_AwardingOrganisation_When_Updated()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                "qan1",
+                "Qual1",
+                ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, "qan1", "Qual1");
+            importRecord.OrganisationName = "Updated Name";
+
+            ApplyMockBehaviour(
+                importRecord,
+                new List<QualificationDTO> { importRecord },
+                eligibleForFunding: false,
+                changesPresent: true,
+                keyFieldsChanged: false);
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert
+            var count = await _dbContext.AwardingOrganisation
+                .CountAsync(x => x.Ukprn == organisationId);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task OfqualImportService_Should_Not_Update_AwardingOrganisation_When_No_Changes_Detected()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                "qan1",
+                "Qual1",
+                ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, "qan1", "Qual1");
+
+            ApplyMockBehaviour(
+                importRecord,
+                new List<QualificationDTO> { importRecord },
+                eligibleForFunding: false,
+                changesPresent: false,
+                keyFieldsChanged: false);
+
+            var original = await _dbContext.AwardingOrganisation
+                .SingleAsync(x => x.Ukprn == organisationId);
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert
+            var updated = await _dbContext.AwardingOrganisation
+                .SingleAsync(x => x.Ukprn == organisationId);
+
+            Assert.Equal(original.NameOfqual, updated.NameOfqual);
+            Assert.Equal(original.Acronym, updated.Acronym);
+            Assert.Equal(original.RecognitionNumber, updated.RecognitionNumber);
+        }
+
+        [Fact]
+        public async Task OfqualImportService_Should_Update_AwardingOrganisation_When_Only_Acronym_Changes()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                "qan1",
+                "Qual1",
+                ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, "qan1", "Qual1");
+
+            importRecord.OrganisationAcronym = "NEW-ACR";
+
+            ApplyMockBehaviour(
+                importRecord,
+                new List<QualificationDTO> { importRecord },
+                eligibleForFunding: false,
+                changesPresent: true,
+                keyFieldsChanged: true);
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert
+            var org = await _dbContext.AwardingOrganisation
+                .SingleAsync(x => x.Ukprn == organisationId);
+
+            Assert.Equal("NEW-ACR", org.Acronym);
+        }
+
+        [Fact]
+        public async Task OfqualImportService_Should_Update_AwardingOrganisation_When_Only_RecognitionNumber_Changes()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                "qan1",
+                "Qual1",
+                ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, "qan1", "Qual1");
+
+            importRecord.OrganisationRecognitionNumber = "RN-UPDATED";
+
+            ApplyMockBehaviour(
+                importRecord,
+                new List<QualificationDTO> { importRecord },
+                eligibleForFunding: false,
+                changesPresent: true,
+                keyFieldsChanged: true);
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert
+            var org = await _dbContext.AwardingOrganisation
+                .SingleAsync(x => x.Ukprn == organisationId);
+
+            Assert.Equal("RN-UPDATED", org.RecognitionNumber);
+        }
+
+        [Fact]
+        public async Task OfqualImportService_Should_Not_Update_Anything_When_No_Changes()
+        {
+            // Arrange
+            await PopulateDbWithReferenceData();
+
+            var organisationId = 10001;
+            var qan = "qan1";
+            var name = "Qual1";
+
+            await CreateQualificationRecordSet(
+                organisationId,
+                qan,
+                name,
+                processStatus: ProcessStageNoAction);
+
+            var service = CreateImportServiceWithDb();
+
+            var importRecord = CreateImportRecord(organisationId, qan, name);
+            var importRecords = new List<QualificationDTO> { importRecord };
+
+            ApplyMockBehaviour(
+                importRecord,
+                importRecords,
+                eligibleForFunding: false,
+                changesPresent: false,
+                keyFieldsChanged: false,
+                failureReason: ImportReason.NoAction);
+
+            var versionCountBefore = await _dbContext.QualificationVersions.CountAsync();
+            var discussionCountBefore = await _dbContext.QualificationDiscussionHistory.CountAsync();
+
+            // Act
+            await service.ProcessQualificationsDataAsync();
+
+            // Assert (only observable behaviour)
+            var versionCountAfter = await _dbContext.QualificationVersions.CountAsync();
+            var discussionCountAfter = await _dbContext.QualificationDiscussionHistory.CountAsync();
+
+            Assert.Equal(versionCountBefore, versionCountAfter);
+            Assert.Equal(discussionCountBefore, discussionCountAfter);
+
+            var qualification = await _dbContext.Qualification.SingleAsync(x => x.Qan == qan);
+            Assert.Equal(name, qualification.QualificationName);
+        }
+
         private async Task CreateFundingOffers(List<QualificationVersions> qualificationVersions)
         {
             var qualificationVersion = qualificationVersions.OrderByDescending(o => o.Version).First();

--- a/src/SFA.DAS.AODP.Jobs/Functions/FundedQualificationsDataFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/FundedQualificationsDataFunction.cs
@@ -1,15 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using RestEase;
-using SFA.DAS.AODP.Common.Enum;
-using SFA.DAS.AODP.Infrastructure.Context;
-using SFA.DAS.AODP.Infrastructure.Interfaces;
-using SFA.DAS.AODP.Jobs.Interfaces;
-using SFA.DAS.AODP.Jobs.Services.CSV;
-using SFA.DAS.AODP.Models.Config;
 using SFA.DAS.AODP.Models.Qualification;
 
 namespace SFA.DAS.AODP.Functions
@@ -22,13 +11,15 @@ namespace SFA.DAS.AODP.Functions
         private readonly IJobConfigurationService _jobConfigurationService;
         private readonly IFundedQualificationWriter _fundedQualificationWriter;
         private readonly IQualificationsRepository _qualificationsRepository;
+        private readonly IQualificationVersionRepository _qualificationVersionRepository;
 
         public FundedQualificationsDataFunction(ILogger<FundedQualificationsDataFunction> logger,            
             ICsvReaderService csvReaderService,
             AodpJobsConfiguration config, 
             IJobConfigurationService jobConfigurationService, 
             IFundedQualificationWriter fundedQualificationWriter,
-            IQualificationsRepository qualificationsRepository)
+            IQualificationsRepository qualificationsRepository,
+            IQualificationVersionRepository qualificationVersionRepository)
         {
             _logger = logger;        
             _csvReaderService = csvReaderService;     
@@ -36,6 +27,7 @@ namespace SFA.DAS.AODP.Functions
             _jobConfigurationService = jobConfigurationService;
             _fundedQualificationWriter = fundedQualificationWriter;
             _qualificationsRepository = qualificationsRepository;
+            _qualificationVersionRepository = qualificationVersionRepository;
         }
 
         [Function("ApprovedQualificationsDataFunction")]
@@ -86,9 +78,8 @@ namespace SFA.DAS.AODP.Functions
                     jobControl.JobRunId = await _jobConfigurationService.InsertJobRunAsync(jobControl.JobId, username, JobStatus.Running);
                 }
 
-                var qualifications = await _qualificationsRepository.GetQualificationsAsync();              
-                var organisations = await _qualificationsRepository.GetAwardingOrganisationsAsync();
-                
+                var qualificationCache = await _qualificationVersionRepository.GetLatestQualificationVersionSnapshotsAsync();
+
                 var totalRecords = 0;
                 var totalArchivedRecords = 0;
 
@@ -96,7 +87,7 @@ namespace SFA.DAS.AODP.Functions
                 if (jobControl.ImportFundedCsv)
                 {
                     _logger.LogInformation($"[{nameof(FundedQualificationsDataFunction)}] -> Importing Funded CSV");
-                    var approvedQualifications = await _csvReaderService.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(fundedUrlFilePath, qualifications, organisations, _logger);
+                    var approvedQualifications = await _csvReaderService.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(fundedUrlFilePath, qualificationCache, _logger);
                     //Commented out method to read a file from disk, useful for testing
                     //var path = "D:\\Source\\Repos\\das-aodp-jobs\\src\\SFA.DAS.AODP.Jobs\\Data\\approved.csv";
                     //var approvedQualifications = _csvReaderService.ReadCSVFromFilePath<FundedQualificationDTO, FundedQualificationsImportClassMap>(path, qualifications, organisations, _logger);
@@ -120,7 +111,7 @@ namespace SFA.DAS.AODP.Functions
                 if (jobControl.ImportArchivedCsv)
                 {
                     _logger.LogInformation($"[{nameof(FundedQualificationsDataFunction)}] -> Importing Archived CSV");
-                    var archivedQualifications = await _csvReaderService.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(archivedUrlFilePath, qualifications, organisations, _logger);
+                    var archivedQualifications = await _csvReaderService.ReadCsvFileFromUrlAsync<FundedQualificationDTO, FundedQualificationsImportClassMap>(archivedUrlFilePath, qualificationCache, _logger);
                     if (archivedQualifications.Any())
                     {
                         if (!tablesCleared)

--- a/src/SFA.DAS.AODP.Jobs/Services/CSV/FundedQualificationsImportClassMap.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/CSV/FundedQualificationsImportClassMap.cs
@@ -1,26 +1,22 @@
 ﻿using CsvHelper.Configuration;
-using Microsoft.Extensions.Logging;
-using SFA.DAS.AODP.Data.Entities;
 using SFA.DAS.AODP.Models.Qualification;
+using static SFA.DAS.AODP.Infrastructure.Repositories.QualificationVersionRepository;
 
 namespace SFA.DAS.AODP.Jobs.Services.CSV
 {
     public class FundedQualificationsImportClassMap : ClassMap<FundedQualificationDTO>
     {
-        private readonly Dictionary<string, Guid> _qualificationNumberToIdCache;
-        private readonly Dictionary<string, Guid> _organsationNameToIdCache;
+        private readonly Dictionary<string, (Guid? qualificationId, Guid? organisationId)> _qualificationLookupCache;
         private readonly ILogger _logger;
-        private Guid? _currentQualificationId;
+        private readonly DateTime _minDate = new DateTime(1753, 1, 1);
 
         public FundedQualificationsImportClassMap(
             List<string> headers,
-            List<Qualification> qualifications,
-            List<AwardingOrganisation> organisations,
+            List<QualificationLookupItem> qualificationLookupItems,
             ILogger logger)         
         {
             _logger = logger;
-            _qualificationNumberToIdCache = qualifications.ToDictionary(q => q.Qan, q => q.Id);
-            _organsationNameToIdCache = organisations.ToDictionary(q => q.NameOfqual, q => q.Id);
+            _qualificationLookupCache = qualificationLookupItems.ToDictionary(q => q.Qan, q => (q.QualificationId, q.AwardingOrganisationId));
 
             Map(m => m.Id).Convert(row => {
                 return Guid.NewGuid();
@@ -30,47 +26,34 @@ namespace SFA.DAS.AODP.Jobs.Services.CSV
                 .Name("DateOfOfqualDataSnapshot")
                 .TypeConverterOption.Format("dd/MM/yyyy");
 
-            // Map QualificationId by looking up qualification number in the cache
-            Map(m => m.QualificationId).Convert(row => {
-                var qualificationNumber = row.Row.GetField<string>("QualificationNumber");
+            Map(m => m.QualificationId).Convert(row =>
+            {
+                var qan = row.Row.GetField<string>("QualificationNumber");
 
-                if (string.IsNullOrEmpty(qualificationNumber))
+                if (string.IsNullOrWhiteSpace(qan))
                 {
                     _logger.LogWarning("Empty qualification number found in CSV data");
-                    _currentQualificationId = default;
                     return default;
                 }
 
-                if (_qualificationNumberToIdCache.TryGetValue(qualificationNumber, out Guid qualificationId))
-                {
-                    _currentQualificationId = qualificationId;
-                    return _currentQualificationId;
-                }
-                else
-                {                    
-                    _currentQualificationId = default;
-                    return default;
-                }
+                return _qualificationLookupCache.TryGetValue(qan, out var value)
+                    ? value.qualificationId
+                    : null;
             });
 
-            // Map AwardingOrganisationId by looking up the org name in the cache
-            Map(m => m.AwardingOrganisationId).Convert(row => {
-                var awardingOrganisationName = row.Row.GetField<string>("AwardingOrganisation");
+            Map(m => m.AwardingOrganisationId).Convert(row =>
+            {
+                var qan = row.Row.GetField<string>("QualificationNumber");
 
-                if (string.IsNullOrEmpty(awardingOrganisationName))
+                if (string.IsNullOrWhiteSpace(qan))
                 {
-                    _logger.LogWarning("Empty awarding organistion name found in CSV data");
+                    _logger.LogWarning("Empty qualification number found in CSV data");
                     return default;
                 }
 
-                if (_organsationNameToIdCache.TryGetValue(awardingOrganisationName, out Guid organisationId))
-                {
-                    return organisationId;
-                }
-                else
-                {                   
-                    return default;
-                }
+                return _qualificationLookupCache.TryGetValue(qan, out var value)
+                    ? value.organisationId
+                    : null;
             });
 
             Map(m => m.Level).Name("Level");
@@ -79,40 +62,63 @@ namespace SFA.DAS.AODP.Jobs.Services.CSV
             Map(m => m.SectorSubjectArea).Name("SectorSubjectArea");
             Map(m => m.Status).Name("Status");
             Map(m => m.AwardingOrganisationURL).Name("AwardingOrganisationURL");
-            Map(m => m.Offers).Convert(r =>
+
+            Map(m => m.Offers).Convert(row =>
             {
                 var offers = new List<FundedQualificationOfferDTO>();
 
+                var qan = row.Row.GetField<string>("QualificationNumber");
+
+                if (string.IsNullOrWhiteSpace(qan))
+                {
+                    _logger.LogWarning("Empty qualification number found in CSV data for offers");
+                    return offers;
+                }
+
+                if (!_qualificationLookupCache.TryGetValue(qan, out var lookup))
+                {
+                    return offers;
+                }
+
+                if (!lookup.qualificationId.HasValue)
+                {
+                    return offers;
+                }
+
                 foreach (var item in headers)
                 {
-                    var offerName = item.Split("_")[0];
+                    var offerName = item.Split('_')[0];
 
-                    DateTime? endDate = null;
-                    if (DateTime.TryParse(r.Row.GetField($"{offerName}_FundingApprovalEndDate"), out DateTime parsedEnd) && parsedEnd >= new DateTime(1753, 1, 1))
-                    {
-                        endDate = parsedEnd;
-                    }
+                    var endKey = $"{offerName}_FundingApprovalEndDate";
+                    var startKey = $"{offerName}_FundingApprovalStartDate";
+                    var notesKey = $"{offerName}_Notes";
+                    var fundingKey = $"{offerName}_FundingAvailable";
 
-                    DateTime? startDate = null;
-                    if (DateTime.TryParse(r.Row.GetField($"{offerName}_FundingApprovalStartDate"), out DateTime parsedStart) && parsedStart >= new DateTime(1753, 1, 1))
-                    {
-                        startDate = parsedStart;
-                    }
+                    var endDateRaw = row.Row.GetField(endKey);
+                    var startDateRaw = row.Row.GetField(startKey);
 
-                    if (_currentQualificationId.HasValue)
+                    DateTime? endDate =
+                        DateTime.TryParse(endDateRaw, out var e) && e >= _minDate
+                            ? e
+                            : null;
+
+                    DateTime? startDate =
+                        DateTime.TryParse(startDateRaw, out var s) && s >= _minDate
+                            ? s
+                            : null;
+
+                    offers.Add(new FundedQualificationOfferDTO
                     {
-                        offers.Add(new FundedQualificationOfferDTO()
-                        {
-                            Id = Guid.NewGuid(),
-                            QualificationId = _currentQualificationId.Value,
-                            Name = offerName,
-                            Notes = r.Row.GetField($"{offerName}_Notes"),
-                            FundingAvailable = r.Row.GetField($"{offerName}_FundingAvailable"),
-                            FundingApprovalEndDate = endDate,
-                            FundingApprovalStartDate = startDate,
-                        });
-                    }
-                };
+                        Id = Guid.NewGuid(),
+                        QualificationId = lookup.qualificationId.Value,
+                        Name = offerName,
+                        Notes = row.Row.GetField(notesKey),
+                        FundingAvailable = row.Row.GetField(fundingKey),
+                        FundingApprovalEndDate = endDate,
+                        FundingApprovalStartDate = startDate,
+                    });
+                }
+
                 return offers;
             });
 

--- a/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
@@ -1,18 +1,8 @@
 ﻿using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RestEase;
-using SFA.DAS.AODP.Common.Enum;
 using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Infrastructure.Context;
-using SFA.DAS.AODP.Infrastructure.Interfaces;
-using SFA.DAS.AODP.Jobs.Client;
-using SFA.DAS.AODP.Jobs.Interfaces;
 using SFA.DAS.AODP.Jobs.Models;
 using SFA.DAS.AODP.Models.Qualification;
-using System.Diagnostics;
 using System.Text.Json;
 using static SFA.DAS.AODP.Jobs.Services.ChangeDetectionService;
 
@@ -131,10 +121,27 @@ namespace SFA.DAS.AODP.Jobs.Services
 
                 var organisationCache = (await _applicationDbContext.AwardingOrganisation
                     .AsNoTracking()
-                    .Where(w => w.Ukprn.HasValue)
-                    .Select(o => new { Ukprn = o.Ukprn ?? 0, o.Id })
+                    .Where(w => w.Ukprn.HasValue && w.Ukprn.Value > 0)
+                    .Select(o => new
+                    {
+                        o.Ukprn,
+                        o.Id,
+                        o.NameOfqual,
+                        o.NameLegal,
+                        o.Acronym,
+                        o.RecognitionNumber
+                    })
                     .ToListAsync())
-                    .ToDictionary(a => a.Ukprn, a => a.Id);
+                    .ToDictionary(
+                        x => x.Ukprn!.Value,
+                        x => new OrganisationCacheItem(
+                            x.Id,
+                            x.NameOfqual,
+                            x.NameLegal,
+                            x.Acronym,
+                            x.RecognitionNumber
+                        )
+                    );
 
                 var qualificationCache = (await _applicationDbContext.Qualification
                     .AsNoTracking()
@@ -175,9 +182,6 @@ namespace SFA.DAS.AODP.Jobs.Services
                     var newQualifications = new List<Qualification>();
                     var newQualificationVersions = new List<QualificationVersions>();
                     var newQualificationDiscussions = new List<QualificationDiscussionHistory>();
-                    var updatedQualifications = new List<Qualification>();
-                    var updatedQualificationFundings = new List<QualificationFunding>();
-                    var updatedQualificationFeedbacks = new List<QualificationFundingFeedback>();
 
                     var versionFieldChanges = new List<VersionFieldChanges>();
                     var processStatuses = new List<Data.Entities.ProcessStatus>();
@@ -187,24 +191,72 @@ namespace SFA.DAS.AODP.Jobs.Services
                     {
                         // Check Organization
                         var organisationId = Guid.Empty;
-                        if (!organisationCache.ContainsKey(importRecord.OrganisationId ?? 0))
+
+                        if (!importRecord.OrganisationId.HasValue || importRecord.OrganisationId.Value <= 0)
                         {
+                            _logger.LogWarning("Invalid OrganisationId for QAN {Qan} in Ofqual import data", importRecord.QualificationNumberNoObliques);
+                            continue;
+                        }
+
+                        //This is stored as Ukprn in our system but is not actually the UKPRN from the API, it is just a unique identifier for the awarding organisation.
+                        var organisationIdentifier = importRecord.OrganisationId.Value;
+
+                        if (!organisationCache.TryGetValue(organisationIdentifier, out var cachedOrganisation))
+                        {
+                            // New organisation
                             organisationId = Guid.NewGuid();
+
                             var organisation = new AwardingOrganisation
                             {
                                 Id = organisationId,
-                                Ukprn = importRecord.OrganisationId,
+                                Ukprn = organisationIdentifier, 
                                 RecognitionNumber = importRecord.OrganisationRecognitionNumber,
                                 NameOfqual = importRecord.OrganisationName,
                                 NameLegal = importRecord.OrganisationName,
                                 Acronym = importRecord.OrganisationAcronym
                             };
+
                             newOrganisations.Add(organisation);
-                            organisationCache[importRecord.OrganisationId ?? 0] = organisationId;
+
+                            organisationCache[organisationIdentifier] = new OrganisationCacheItem(
+                                organisationId,
+                                importRecord.OrganisationName,
+                                importRecord.OrganisationName,
+                                importRecord.OrganisationAcronym,
+                                importRecord.OrganisationRecognitionNumber
+                            );
                         }
                         else
-                        { 
-                            organisationId = organisationCache[importRecord.OrganisationId ?? 0]; 
+                        {
+                            organisationId = cachedOrganisation.Id;
+
+                            bool organisationChanged =
+                                cachedOrganisation.NameOfqual != importRecord.OrganisationName ||
+                                cachedOrganisation.NameLegal != importRecord.OrganisationName ||
+                                cachedOrganisation.Acronym != importRecord.OrganisationAcronym ||
+                                cachedOrganisation.RecognitionNumber != importRecord.OrganisationRecognitionNumber;
+
+                            if (organisationChanged)
+                            {
+                                var organisationToUpdate = await _applicationDbContext.AwardingOrganisation
+                                    .FirstOrDefaultAsync(o => o.Id == organisationId);
+
+                                if (organisationToUpdate != null)
+                                {
+                                    organisationToUpdate.NameOfqual = importRecord.OrganisationName;
+                                    organisationToUpdate.NameLegal = importRecord.OrganisationName;
+                                    organisationToUpdate.Acronym = importRecord.OrganisationAcronym;
+                                    organisationToUpdate.RecognitionNumber = importRecord.OrganisationRecognitionNumber;
+                                }
+
+                                organisationCache[organisationIdentifier] = new OrganisationCacheItem(
+                                    organisationId,
+                                    importRecord.OrganisationName,
+                                    importRecord.OrganisationName,
+                                    importRecord.OrganisationAcronym,
+                                    importRecord.OrganisationRecognitionNumber
+                                );
+                            }
                         }
 
                         // Check Qualification
@@ -425,7 +477,6 @@ namespace SFA.DAS.AODP.Jobs.Services
                                 if (qualificationToUpdate != null)
                                 {
                                     qualificationToUpdate.QualificationName = importRecord.Title;
-                                    updatedQualifications.Add(qualificationToUpdate);
                                 }
 
                             }
@@ -609,5 +660,13 @@ namespace SFA.DAS.AODP.Jobs.Services
 
             return fundingFeedbacks;
         }
+
+        private sealed record OrganisationCacheItem(
+            Guid Id,
+            string? NameOfqual,
+            string? NameLegal,
+            string? Acronym,
+            string? RecognitionNumber
+        );
     }
 }

--- a/src/SFA.DAS.AODP.Jobs/StartupExtensions/AddServiceRegistrationsExtension.cs
+++ b/src/SFA.DAS.AODP.Jobs/StartupExtensions/AddServiceRegistrationsExtension.cs
@@ -37,6 +37,7 @@ public static class AddServiceRegistrationsExtension
         services.AddScoped<ISchedulerClientService, SchedulerClientService>();
         services.AddScoped<IFundedQualificationWriter, FundedQualificationWriter>();
         services.AddScoped<IQualificationsRepository, QualificationsRepository>();
+        services.AddScoped<IQualificationVersionRepository, QualificationVersionRepository>();
         services.AddScoped<IImportRepository, ImportRepository>();
         services.AddAzureClients(clientBuilder =>
         {


### PR DESCRIPTION
processes organisation changes during Ofqual import
Funded import changed to use the awarding organisation linked with the qualification