### PR TITLE
[AWARD-1225] - Added in import fixes to better handle data discrepancies

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/LifeCycleStage.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/LifeCycleStage.cs
@@ -9,6 +9,7 @@ namespace SFA.DAS.AODP.Common.Enum
     public static class LifeCycleStage
     {
         public const string New = "New";
+        public const string Completed = "Completed";
         public const string Changed = "Changed";
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
@@ -3,6 +3,7 @@ using SFA.DAS.AODP.Data.Entities;
 using SFA.DAS.AODP.Jobs.Services;
 using SFA.DAS.AODP.Models.Qualification;
 using Xunit;
+using Shouldly;
 
 namespace SFA.DAS.AODP.Jobs.Test.Application.Services
 {
@@ -33,9 +34,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.False(result.ChangesPresent);
-            Assert.Empty(result.Fields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
         }
 
         [Fact]
@@ -52,9 +53,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Status", result.Fields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldContain("Status");
+            result.KeyFieldsChanged.ShouldBeFalse();
         }
 
         [Fact]
@@ -71,18 +72,56 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Level", result.Fields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldContain("Level");
+            result.KeyFieldsChanged.ShouldBeTrue();
         }
 
         public static IEnumerable<object[]> TitleWhitespaceCases =>
             new List<object[]>
             {
+                // multiple spaces
                 new object[] { "My Qualification Title", "My  Qualification   Title" },
+                // leading/trailing spaces
                 new object[] { "My Qualification Title", " My Qualification Title " },
+                // newline
                 new object[] { "My Qualification Title", "My Qualification Title\n" },
-                new object[] { "My Qualification Title", "My Qualification Title\u00A0" }
+                // no-break space
+                new object[] { "My Qualification Title", "My Qualification Title\u00A0" },
+                // tab
+                new object[] { "My Qualification Title", "My\tQualification Title" },
+                // vertical tab and form feed
+                new object[] { "My Qualification Title", "My Qualification\u000B Title" },
+                new object[] { "My Qualification Title", "My Qualification\u000C Title" },
+                // carriage return
+                new object[] { "My Qualification Title", "My Qualification Title\r" },
+                // various unicode space separators
+                new object[] { "My Qualification Title", "My Qualification\u1680 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2003 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2009 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u200A Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2028 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2029 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u202F Title" },
+                new object[] { "My Qualification Title", "My Qualification\u205F Title" },
+                new object[] { "My Qualification Title", "My Qualification\u3000 Title" },
+                // zero-width / invisible characters
+                new object[] { "My Qualification Title", "My\u200B Qualification Title" },
+                new object[] { "My Qualification Title", "My Qualification\u200C Title" },
+                new object[] { "My Qualification Title", "My\u200D Qualification Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2060 Title" },
+                new object[] { "My Qualification Title", "\uFEFFMy Qualification Title" },
+                // apostrophe/quote variants should normalise to straight apostrophe
+                new object[] { "O'Connor", "O\u2019Connor" },
+                new object[] { "O'Connor", "O\u2018Connor" },
+                new object[] { "O'Connor", "O\u201AConnor" },
+                new object[] { "O'Connor", "O\u201BConnor" },
+                new object[] { "O'Connor", "O\u2032Connor" },
+                new object[] { "O'Connor", "O\uFF07Connor" },
+                // case-only change should be treated as non-key (normalisation compares ignoring case)
+                new object[] { "My Qualification Title", "my qualification title" },
+                // mixed invisible and spacing characters
+                new object[] { "My Qualification Title", " My\u200B Qualification\u00A0 Title\u200D " }
             };
 
         [Theory]
@@ -102,9 +141,10 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Title", result.Fields);
-            Assert.False(result.KeyFieldsChanged);
+            // Whitespace / invisible / case-only changes are normalised away and should not be treated as changes
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
         }
 
         [Fact]
@@ -121,9 +161,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Title", result.Fields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldContain("Title");
+            result.KeyFieldsChanged.ShouldBeTrue();
         }
 
         [Fact]
@@ -143,10 +183,11 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version, org, qual);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Title", result.Fields);
-            Assert.Contains("Level", result.Fields);
-            Assert.True(result.KeyFieldsChanged);
+            // Title whitespace change should be normalised away; Level remains a key change
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldNotContain("Title");
+            result.Fields.ShouldContain("Level");
+            result.KeyFieldsChanged.ShouldBeTrue();
         }
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
@@ -195,6 +195,63 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                 new object[] { "My Qualification Title", " My\u200B Qualification\u00A0 Title\u200D " }
             };
 
+        public static IEnumerable<object[]> HyphenVariantsCases =>
+            new List<object[]>
+            {
+                new object[] { "A-B Qualification", "A\u2010B Qualification" }, // hyphen
+                new object[] { "A-B Qualification", "A\u2011B Qualification" }, // non-breaking hyphen
+                new object[] { "A-B Qualification", "A\u2012B Qualification" }, // figure dash
+                new object[] { "A-B Qualification", "A\u2013B Qualification" }, // en dash
+                new object[] { "A-B Qualification", "A\u2014B Qualification" }, // em dash
+                new object[] { "A-B Qualification", "A\u2015B Qualification" }, // horizontal bar
+                new object[] { "A-B Qualification", "A\u2212B Qualification" }, // minus sign
+                new object[] { "A-B Qualification", "A\uFE58B Qualification" }, // small em dash
+                new object[] { "A-B Qualification", "A\uFE63B Qualification" }, // small hyphen-minus
+                new object[] { "A-B Qualification", "A\uFF0DB Qualification" }  // fullwidth hyphen-minus
+            };
+
+        [Theory]
+        [MemberData(nameof(HyphenVariantsCases))]
+        public void DetectChanges_HyphenVariants_AreNormalised_NoChange(
+            string oldTitle,
+            string newTitle)
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            qual.QualificationName = oldTitle;
+            dto.Title = newTitle;
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            // Various unicode hyphen/dash characters should normalise to a simple hyphen and not be treated as changes
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_HyphenRemoved_IsKeyChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            qual.QualificationName = "A-B Qualification";
+            dto.Title = "A B Qualification"; // hyphen removed -> treated as meaningful change
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldContain("Title");
+            result.KeyFieldsChanged.ShouldBeTrue();
+        }
+
         [Theory]
         [MemberData(nameof(TitleWhitespaceCases))]
         public void DetectChanges_TitleWhitespaceOnly_IsChangeButNotKey(

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Jobs.Services;
-using SFA.DAS.AODP.Models.Qualification;
-using Xunit;
+﻿using SFA.DAS.AODP.Models.Qualification;
 using Shouldly;
 
 namespace SFA.DAS.AODP.Jobs.Test.Application.Services
@@ -75,6 +71,81 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             result.ChangesPresent.ShouldBeTrue();
             result.Fields.ShouldContain("Level");
             result.KeyFieldsChanged.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DetectChanges_ApprovedForDelFundedProgramme_FalseTreatedAsNull_NoChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            dto.ApprovedForDelfundedProgramme = "false"; // treated as null
+            version.ApprovedForDelFundedProgramme = null;
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_ApprovedForDelFundedProgramme_True_IsChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            dto.ApprovedForDelfundedProgramme = "true";
+            version.ApprovedForDelFundedProgramme = null;
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            result.ChangesPresent.ShouldBeTrue();
+            result.Fields.ShouldContain("ApprovedForDelfundedProgramme");
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_LastUpdatedDate_TimeOfDayDifferences_AreIgnored()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            dto.LastUpdatedDate = new DateTime(2024, 1, 1, 13, 30, 0);
+            version.LastUpdatedDate = new DateTime(2024, 1, 1, 0, 0, 0);
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldNotContain("LastUpdatedDate");
+        }
+
+        [Fact]
+        public void DetectChanges_OrganisationName_WithUnicodeAndZeroWidth_AreNormalised_NoChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version, org, qual) = CreateEmptyBaseline();
+
+            dto.OrganisationName = "O'Connor";
+            org.NameOfqual = "O\u2019Connor\u200B"; // curly apostrophe + zero-width space
+
+            // Act
+            var result = sut.DetectChanges(dto, version, org, qual);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.Fields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
         }
 
         public static IEnumerable<object[]> TitleWhitespaceCases =>

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/OfqualImportServiceTests.cs
@@ -40,6 +40,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
         private Fixture _fixture;
         private Guid LifeCycleStageNew = new Guid("00000000-0000-0000-0000-000000000001");
         private Guid LifeCycleStageChanged = new Guid("00000000-0000-0000-0000-000000000002");
+        private Guid LifeCycleStageCompleted = new Guid("00000000-0000-0000-0000-000000000003");
         private Guid ProcessStageNoAction = new Guid("00000000-0000-0000-0000-000000000001");
         private Guid ProcessStageDecision = new Guid("00000000-0000-0000-0000-000000000002");
         private Guid ProcessStageApproved = new Guid("00000000-0000-0000-0000-000000000003");
@@ -231,7 +232,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .Where(w => w.QualificationId == insertedQualification.Id).Single();
             Assert.NotNull(insertedVersion);
             Assert.Equal(Common.Enum.ProcessStatus.NoActionRequired, insertedVersion.ProcessStatus.Name);
-            Assert.Equal(Common.Enum.LifeCycleStage.New, insertedVersion.LifecycleStage.Name);
+            Assert.Equal(Common.Enum.LifeCycleStage.Completed, insertedVersion.LifecycleStage.Name);
 
             // new qualification discussion
             var insertedDiscussion = _dbContext.QualificationDiscussionHistory
@@ -336,7 +337,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .Where(w => w.QualificationId == insertedQualification.Id).First();
             Assert.NotNull(insertedVersion);
             Assert.Equal(Common.Enum.ProcessStatus.NoActionRequired, insertedVersion.ProcessStatus.Name);
-            Assert.Equal(Common.Enum.LifeCycleStage.New, insertedVersion.LifecycleStage.Name);
+            Assert.Equal(Common.Enum.LifeCycleStage.Completed, insertedVersion.LifecycleStage.Name);
 
             // new qualification discussion
             var insertedDiscussion = _dbContext.QualificationDiscussionHistory
@@ -385,7 +386,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             Assert.NotNull(insertedVersion);
             Assert.Equal(2, insertedVersion.Version);
             Assert.Equal(Common.Enum.ProcessStatus.NoActionRequired, insertedVersion.ProcessStatus.Name);
-            Assert.Equal(Common.Enum.LifeCycleStage.Changed, insertedVersion.LifecycleStage.Name);
+            Assert.Equal(Common.Enum.LifeCycleStage.Completed, insertedVersion.LifecycleStage.Name);
 
             // new qualification discussion
             var insertedDiscussion = await _dbContext.QualificationDiscussionHistory
@@ -395,7 +396,7 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .FirstAsync();
             Assert.NotNull(insertedDiscussion);
             Assert.Equal("No Action Required", insertedDiscussion.ActionType.Description);
-            Assert.Equal("No Action required - Changed Qualification (Funding Criteria)", insertedDiscussion.Notes);
+            Assert.Equal("No Action required - Completed Qualification (Funding Criteria)", insertedDiscussion.Notes);
         }
 
         private void ApplyMockBehaviour(QualificationDTO importRecord, List<QualificationDTO> importRecords, bool eligibleForFunding, bool changesPresent, bool keyFieldsChanged, string failureReason = ImportReason.NoAction)
@@ -448,8 +449,8 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .FirstAsync();
             Assert.NotNull(insertedVersion);
             Assert.Equal(2, insertedVersion.Version);
-            Assert.Equal(Common.Enum.ProcessStatus.DecisionRequired, insertedVersion.ProcessStatus.Name);
-            Assert.Equal(Common.Enum.LifeCycleStage.Changed, insertedVersion.LifecycleStage.Name);
+            Assert.Equal(Common.Enum.ProcessStatus.NoActionRequired, insertedVersion.ProcessStatus.Name);
+            Assert.Equal(Common.Enum.LifeCycleStage.Completed, insertedVersion.LifecycleStage.Name);
 
             // new qualification discussion
             var insertedDiscussion = await _dbContext.QualificationDiscussionHistory
@@ -458,10 +459,10 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .Where(w => w.QualificationId == insertedQualification.Id)
                                     .FirstAsync();
             Assert.NotNull(insertedDiscussion);
-            Assert.Equal("Action Required", insertedDiscussion.ActionType.Description);
-            Assert.Equal("Decision Required - Changed Qualification", insertedDiscussion.Notes);
+            Assert.Equal("No Action Required", insertedDiscussion.ActionType.Description);
+            Assert.Equal("No Action Required - Completed Qualification (Funding Criteria)", insertedDiscussion.Notes);
         }
-
+            
         [Fact]
         public async Task ProcessQualificationsDataAsync_ExistingRecord_EligibleForFunding_Approved_KeyFieldsChanged()
         {
@@ -560,7 +561,8 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .Where(w => w.QualificationId == insertedQualification.Id && w.Version == 1)
                                     .FirstAsync();
             Assert.Equal(insertedVersion.ProcessStatus.Name, oldVersion.ProcessStatus.Name);
-            Assert.Equal(Common.Enum.LifeCycleStage.Changed, insertedVersion.LifecycleStage.Name);
+            Assert.Equal(Common.Enum.ProcessStatus.Approved, insertedVersion.ProcessStatus.Name);
+            Assert.Equal(Common.Enum.LifeCycleStage.Completed, insertedVersion.LifecycleStage.Name);
 
             // new qualification discussion
             var insertedDiscussion = await _dbContext.QualificationDiscussionHistory
@@ -569,8 +571,8 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
                                     .Where(w => w.QualificationId == insertedQualification.Id)
                                     .FirstAsync();
             Assert.NotNull(insertedDiscussion);
-            Assert.Equal("Action Required", insertedDiscussion.ActionType.Description);
-            Assert.Equal("Decision Required - Changed Qualification (Minor Fields)", insertedDiscussion.Notes);
+            Assert.Equal("No Action Required", insertedDiscussion.ActionType.Description);
+            Assert.Equal("Approved - Completed Qualification (Minor Fields)", insertedDiscussion.Notes);
         }
 
         [Fact]
@@ -1085,7 +1087,8 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
 
             var lifecycle1 = new Data.Entities.LifecycleStage() { Name = Common.Enum.LifeCycleStage.New, Id = LifeCycleStageNew };
             var lifecycle2 = new Data.Entities.LifecycleStage() { Name = Common.Enum.LifeCycleStage.Changed, Id = LifeCycleStageChanged };
-            await _dbContext.AddRangeAsync(new List<Data.Entities.LifecycleStage>() { lifecycle1, lifecycle2 });
+            var lifecycle3 = new Data.Entities.LifecycleStage() { Name = Common.Enum.LifeCycleStage.Completed, Id = LifeCycleStageCompleted };
+            await _dbContext.AddRangeAsync(new List<Data.Entities.LifecycleStage>() { lifecycle1, lifecycle2, lifecycle3 });
             await _dbContext.SaveChangesAsync();
 
             var fundingOffer1 = new Data.Entities.FundingOffer() { Id = FundingOfferId1, Name = FundingOffer1 };

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -12,27 +12,28 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="10.105.2.2" />
+    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="10.105.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.AODP.Jobs/GlobalUsings.cs
+++ b/src/SFA.DAS.AODP.Jobs/GlobalUsings.cs
@@ -1,5 +1,4 @@
-﻿global using Azure.Core;
-global using Azure.Identity;
+﻿global using Azure.Identity;
 
 global using Microsoft.AspNetCore.Mvc;
 global using Microsoft.Azure.Functions.Worker.Builder;

--- a/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
@@ -45,8 +45,6 @@ namespace SFA.DAS.AODP.Jobs.Services
                     "MinimumGLH",
                     "Tqt",
                     "OperationalEndDate",
-                    "LastUpdatedDate",
-                    "Version", //internal version numbers do not match Ofqual version numbers (we start from 1)
                     "OfferedInternationally"
                 };
         }
@@ -63,8 +61,8 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(newRecord.AppearsOnPublicRegister != qualificationVersion.AppearsOnPublicRegister, "AppearsOnPublicRegister");
             fields = fields.AppendIf(newRecord.ApprenticeshipStandardReferenceNumber != qualificationVersion.ApprenticeshipStandardReferenceNumber, "ApprenticeshipStandardReferenceNumber");
             fields = fields.AppendIf(newRecord.ApprenticeshipStandardTitle != qualificationVersion.ApprenticeshipStandardTitle, "ApprenticeshipStandardTitle");
-            fields = fields.AppendIf(newRecord.ApprovedForDelfundedProgramme != qualificationVersion.ApprovedForDelFundedProgramme, "ApprovedForDelfundedProgramme");
-            fields = fields.AppendIf(newRecord.CertificationEndDate != qualificationVersion.CertificationEndDate, "CertificationEndDate");
+            fields = fields.AppendIf(NormaliseBoolean(newRecord.ApprovedForDelfundedProgramme, treatFalseAsNull: true) != NormaliseBoolean(qualificationVersion.ApprovedForDelFundedProgramme, treatFalseAsNull: true), "ApprovedForDelfundedProgramme");
+            fields = fields.AppendIf(NormaliseDate(newRecord.CertificationEndDate) != NormaliseDate(qualificationVersion.CertificationEndDate), "CertificationEndDate");
             fields = fields.AppendIf(newRecord.EighteenPlus != qualificationVersion.EighteenPlus, "EighteenPlus");
             fields = fields.AppendIf(newRecord.EntitlementFrameworkDesignation != qualificationVersion.EntitlementFrameworkDesign, "EntitlementFrameworkDesignation");
             fields = fields.AppendIf(newRecord.EqfLevel != qualificationVersion.EqfLevel, "EqfLevel");
@@ -74,8 +72,8 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(newRecord.GradingScale != qualificationVersion.GradingScale, "GradingScale");
             fields = fields.AppendIf(newRecord.GradingType != qualificationVersion.GradingType, "GradingType");
             fields = fields.AppendIf(newRecord.ImportStatus != qualificationVersion.ImportStatus, "ImportStatus");
-            fields = fields.AppendIf(newRecord.InsertedDate != qualificationVersion.InsertedDate, "InsertedDate");
-            fields = fields.AppendIf(newRecord.LastUpdatedDate != qualificationVersion.LastUpdatedDate, "LastUpdatedDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.InsertedDate) != NormaliseDate(qualificationVersion.InsertedDate), "InsertedDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.LastUpdatedDate) != NormaliseDate(qualificationVersion.LastUpdatedDate), "LastUpdatedDate");
             fields = fields.AppendIf(newRecord.Level != qualificationVersion.Level, "Level");
             fields = fields.AppendIf(newRecord.LinkToSpecification != qualificationVersion.LinkToSpecification, "LinkToSpecification");
             fields = fields.AppendIf(newRecord.MaximumGlh != qualificationVersion.MaximumGlh, "MaximumGlh");
@@ -85,11 +83,11 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(newRecord.OfferedInEngland != qualificationVersion.OfferedInEngland, "OfferedInEngland");
             fields = fields.AppendIf(newRecord.OfferedInNorthernIreland != qualificationVersion.OfferedInNi, "OfferedInNorthernIreland");
             fields = fields.AppendIf(newRecord.OfferedInternationally != qualificationVersion.OfferedInternationally, "OfferedInternationally");
-            fields = fields.AppendIf(newRecord.OperationalEndDate != qualificationVersion.OperationalEndDate, "OperationalEndDate");
-            fields = fields.AppendIf(newRecord.OperationalStartDate != qualificationVersion.OperationalStartDate, "OperationalStartDate");
-          
+            fields = fields.AppendIf(NormaliseDate(newRecord.OperationalEndDate) != NormaliseDate(qualificationVersion.OperationalEndDate), "OperationalEndDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.OperationalStartDate) != NormaliseDate(qualificationVersion.OperationalStartDate), "OperationalStartDate");
+
             fields = fields.AppendIf(newRecord.OrganisationAcronym != awardingOrganisation.Acronym, "OrganisationAcronym");
-            fields = fields.AppendIf(newRecord.OrganisationName != awardingOrganisation.NameOfqual, "OrganisationName");
+            fields = fields.AppendIf(Normalise(newRecord.OrganisationName) != Normalise(awardingOrganisation.NameOfqual), "OrganisationName");
             fields = fields.AppendIf(newRecord.OrganisationId != awardingOrganisation.Ukprn, "OrganisationId");
             fields = fields.AppendIf(newRecord.OrganisationRecognitionNumber != awardingOrganisation.RecognitionNumber, "OrganisationRecognitionNumber");
 
@@ -98,8 +96,8 @@ namespace SFA.DAS.AODP.Jobs.Services
 
             fields = fields.AppendIf(newRecord.QualificationNumberNoObliques != qualification.Qan, "QualificationNumberNoObliques");
             fields = fields.AppendIf(newRecord.RegulatedByNorthernIreland != qualificationVersion.RegulatedByNorthernIreland, "RegulatedByNorthernIreland");
-            fields = fields.AppendIf(newRecord.RegulationStartDate != qualificationVersion.RegulationStartDate, "RegulationStartDate");
-            fields = fields.AppendIf(newRecord.ReviewDate != qualificationVersion.ReviewDate, "ReviewDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.RegulationStartDate) != NormaliseDate(qualificationVersion.RegulationStartDate), "RegulationStartDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.ReviewDate) != NormaliseDate(qualificationVersion.ReviewDate), "ReviewDate");
             fields = fields.AppendIf(newRecord.SixteenToEighteen != qualificationVersion.SixteenToEighteen, "SixteenToEighteen");
             fields = fields.AppendIf(newRecord.Specialism != qualificationVersion.Specialism, "Specialism");            
             fields = fields.AppendIf(newRecord.SubLevel != qualificationVersion.SubLevel, "SubLevel");
@@ -108,7 +106,7 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(newRecord.Tqt != qualificationVersion.Tqt, "Tqt");
             fields = fields.AppendIf(newRecord.Type != qualificationVersion.Type, "Type");
             fields = fields.AppendIf(newRecord.TypeId != qualificationVersion.TypeId, "Type");
-            fields = fields.AppendIf(newRecord.UiLastUpdatedDate != qualificationVersion.UiLastUpdatedDate, "UiLastUpdatedDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.UiLastUpdatedDate) != NormaliseDate(qualificationVersion.UiLastUpdatedDate), "UiLastUpdatedDate");
             fields = fields.AppendIf(newRecord.IntentionToSeekFundingInEngland != qualificationVersion.IntentionToSeekFundingInEngland, "IntentionToSeekFundingInEngland");
 
             var results = new DetectionResults() { Fields = fields, ChangesPresent = fields.Any() };
@@ -119,30 +117,116 @@ namespace SFA.DAS.AODP.Jobs.Services
 
                 if (keyFieldsChanged.Contains("Title") && IsWhitespaceChange(newRecord.Title, qualification.QualificationName))
                 {
-                    keyFieldsChanged.RemoveAll(f => f == "Title");
+                    keyFieldsChanged.RemoveAll(f => string.Equals(f, "Title", StringComparison.InvariantCultureIgnoreCase));
+                    results.Fields.RemoveAll(f => string.Equals(f, "Title", StringComparison.InvariantCultureIgnoreCase));
                 }
 
                 results.KeyFieldsChanged = keyFieldsChanged.Any();
+
+                // Recalculate ChangesPresent because we may have removed fields (e.g. Title when only whitespace/case changed)
+                results.ChangesPresent = results.Fields.Any();
             }
 
             return results;
         }
 
-        private static string Normalize(string? s)
+        private static bool? NormaliseBoolean(string? value, bool treatFalseAsNull = false)
         {
-            if (string.IsNullOrWhiteSpace(s)) return string.Empty;
-            s = s.Replace('\u00A0', ' ');              
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            var normalisedValue = value.Trim();
+
+            bool? parsedValue = normalisedValue.ToLowerInvariant() switch
+            {
+                "true" => true,
+                "false" => false,
+
+                "1" => true,
+                "0" => false,
+
+                "yes" => true,
+                "no" => false,
+
+                _ => null
+            };
+
+            if (treatFalseAsNull && parsedValue == false)
+            {
+                return null;
+            }
+
+            return parsedValue;
+        }
+
+        private static DateTime? NormaliseDate(DateTime? date)
+        {
+            return date?.Date;
+        }
+
+        private static string Normalise(string? s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return string.Empty;
+            }
+
+            s = s
+                // Standard/control whitespace
+                .Replace('\u0009', ' ') // Tab
+                .Replace('\u000A', ' ') // Line feed
+                .Replace('\u000B', ' ') // Vertical tab
+                .Replace('\u000C', ' ') // Form feed
+                .Replace('\u000D', ' ') // Carriage return
+
+                // Unicode space separators
+                .Replace('\u00A0', ' ') // No-break space
+                .Replace('\u1680', ' ') // Ogham space mark
+                .Replace('\u2000', ' ') // En quad
+                .Replace('\u2001', ' ') // Em quad
+                .Replace('\u2002', ' ') // En space
+                .Replace('\u2003', ' ') // Em space
+                .Replace('\u2004', ' ') // Three-per-em space
+                .Replace('\u2005', ' ') // Four-per-em space
+                .Replace('\u2006', ' ') // Six-per-em space
+                .Replace('\u2007', ' ') // Figure space
+                .Replace('\u2008', ' ') // Punctuation space
+                .Replace('\u2009', ' ') // Thin space
+                .Replace('\u200A', ' ') // Hair space
+                .Replace('\u2028', ' ') // Line separator
+                .Replace('\u2029', ' ') // Paragraph separator
+                .Replace('\u202F', ' ') // Narrow no-break space
+                .Replace('\u205F', ' ') // Medium mathematical space
+                .Replace('\u3000', ' ') // Ideographic space
+
+                // Zero-width/invisible formatting characters
+                .Replace("\u200B", "") // Zero-width space / ZWSP
+                .Replace("\u200C", "") // Zero-width non-joiner
+                .Replace("\u200D", "") // Zero-width joiner
+                .Replace("\u2060", "") // Word joiner
+                .Replace("\uFEFF", "") // Zero-width no-break space / byte order mark
+
+                // Apostrophe/single quote variants
+                .Replace('\u2018', '\'') // Left single quotation mark
+                .Replace('\u2019', '\'') // Right single quotation mark / curly apostrophe
+                .Replace('\u201A', '\'') // Single low-9 quotation mark
+                .Replace('\u201B', '\'') // Single high-reversed-9 quotation mark
+                .Replace('\u2032', '\'') // Prime
+                .Replace('\uFF07', '\''); // Fullwidth apostrophe
+
             return Regex.Replace(
                 s.Trim(),
                 @"\s+",
                 " ",
                 RegexOptions.None,
-                TimeSpan.FromMilliseconds(50)); 
+                TimeSpan.FromMilliseconds(50));
         }
 
         private static bool IsWhitespaceChange(string? newValue, string? oldValue)
         {
-            return string.Equals(Normalize(newValue), Normalize(oldValue), StringComparison.OrdinalIgnoreCase)
+            return string.Equals(Normalise(newValue), Normalise(oldValue), StringComparison.OrdinalIgnoreCase)
                    && !string.Equals(newValue ?? "", oldValue ?? "", StringComparison.Ordinal);
         }
     }

--- a/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
@@ -27,33 +27,38 @@ namespace SFA.DAS.AODP.Jobs.Services
         public ChangeDetectionService()
         {
             _keyFields = new List<string>()
-                {
-                    "OrganisationName",
-                    "Title",
-                    "Level",
-                    "Type",
-                    "TotalCredits",
-                    "Ssa",
-                    "GradingType",
-                    "OfferedInEngland",
-                    "PreSixteen",
-                    "SixteenToEighteen",
-                    "EighteenPlus",
-                    "NineteenPlus",
-                    "IntentionToSeekFundingInEngland", 
-                    "GLH",
-                    "MinimumGLH",
-                    "Tqt",
-                    "OperationalEndDate",
-                    "OfferedInternationally"
-                };
+            {
+                "OrganisationName",
+                "Title",
+                "Level",
+                "Type",
+                "TotalCredits",
+                "Ssa",
+                "GradingType",
+                "OfferedInEngland",
+                "PreSixteen",
+                "SixteenToEighteen",
+                "EighteenPlus",
+                "NineteenPlus",
+                "IntentionToSeekFundingInEngland",
+                "GLH",
+                "MinimumGLH",
+                "Tqt",
+                "OperationalEndDate",
+                "OfferedInternationally"
+            };
         }
 
-        public DetectionResults DetectChanges(QualificationDTO newRecord, QualificationVersions qualificationVersion, AwardingOrganisation awardingOrganisation, Qualification qualification)
+        public DetectionResults DetectChanges(
+            QualificationDTO newRecord,
+            QualificationVersions qualificationVersion,
+            AwardingOrganisation awardingOrganisation,
+            Qualification qualification)
         {
             // Could use Reflection here, but records being compared have mismatched names, different field types, or information located in other structures
 
-            var fields = new List<string>();       
+            var fields = new List<string>();
+
             fields = fields.AppendIf(newRecord.Ssa != qualificationVersion.Ssa, "Ssa");
             fields = fields.AppendIf(newRecord.Pathways != qualificationVersion.Pathways, "Pathways");
             fields = fields.AppendIf(newRecord.Status != qualificationVersion.Status, "Status");
@@ -87,7 +92,7 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(NormaliseDate(newRecord.OperationalStartDate) != NormaliseDate(qualificationVersion.OperationalStartDate), "OperationalStartDate");
 
             fields = fields.AppendIf(newRecord.OrganisationAcronym != awardingOrganisation.Acronym, "OrganisationAcronym");
-            fields = fields.AppendIf(Normalise(newRecord.OrganisationName) != Normalise(awardingOrganisation.NameOfqual), "OrganisationName");
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.OrganisationName), Normalise(awardingOrganisation.NameOfqual), StringComparison.OrdinalIgnoreCase), "OrganisationName");
             fields = fields.AppendIf(newRecord.OrganisationId != awardingOrganisation.Ukprn, "OrganisationId");
             fields = fields.AppendIf(newRecord.OrganisationRecognitionNumber != awardingOrganisation.RecognitionNumber, "OrganisationRecognitionNumber");
 
@@ -99,9 +104,9 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(NormaliseDate(newRecord.RegulationStartDate) != NormaliseDate(qualificationVersion.RegulationStartDate), "RegulationStartDate");
             fields = fields.AppendIf(NormaliseDate(newRecord.ReviewDate) != NormaliseDate(qualificationVersion.ReviewDate), "ReviewDate");
             fields = fields.AppendIf(newRecord.SixteenToEighteen != qualificationVersion.SixteenToEighteen, "SixteenToEighteen");
-            fields = fields.AppendIf(newRecord.Specialism != qualificationVersion.Specialism, "Specialism");            
+            fields = fields.AppendIf(newRecord.Specialism != qualificationVersion.Specialism, "Specialism");
             fields = fields.AppendIf(newRecord.SubLevel != qualificationVersion.SubLevel, "SubLevel");
-            fields = fields.AppendIf(newRecord.Title != qualification.QualificationName, "Title");
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.Title), Normalise(qualification.QualificationName), StringComparison.OrdinalIgnoreCase), "Title");
             fields = fields.AppendIf(newRecord.TotalCredits != qualificationVersion.TotalCredits, "TotalCredits");
             fields = fields.AppendIf(newRecord.Tqt != qualificationVersion.Tqt, "Tqt");
             fields = fields.AppendIf(newRecord.Type != qualificationVersion.Type, "Type");
@@ -109,22 +114,17 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(NormaliseDate(newRecord.UiLastUpdatedDate) != NormaliseDate(qualificationVersion.UiLastUpdatedDate), "UiLastUpdatedDate");
             fields = fields.AppendIf(newRecord.IntentionToSeekFundingInEngland != qualificationVersion.IntentionToSeekFundingInEngland, "IntentionToSeekFundingInEngland");
 
-            var results = new DetectionResults() { Fields = fields, ChangesPresent = fields.Any() };
+            var results = new DetectionResults
+            {
+                Fields = fields,
+                ChangesPresent = fields.Count > 0
+            };
 
             if (results.ChangesPresent)
             {
                 var keyFieldsChanged = results.Fields.Intersect(_keyFields).ToList();
 
-                if (keyFieldsChanged.Contains("Title") && IsWhitespaceChange(newRecord.Title, qualification.QualificationName))
-                {
-                    keyFieldsChanged.RemoveAll(f => string.Equals(f, "Title", StringComparison.InvariantCultureIgnoreCase));
-                    results.Fields.RemoveAll(f => string.Equals(f, "Title", StringComparison.InvariantCultureIgnoreCase));
-                }
-
-                results.KeyFieldsChanged = keyFieldsChanged.Any();
-
-                // Recalculate ChangesPresent because we may have removed fields (e.g. Title when only whitespace/case changed)
-                results.ChangesPresent = results.Fields.Any();
+                results.KeyFieldsChanged = keyFieldsChanged.Count > 0;
             }
 
             return results;
@@ -173,61 +173,55 @@ namespace SFA.DAS.AODP.Jobs.Services
                 return string.Empty;
             }
 
-            s = s
-                // Standard/control whitespace
-                .Replace('\u0009', ' ') // Tab
-                .Replace('\u000A', ' ') // Line feed
-                .Replace('\u000B', ' ') // Vertical tab
-                .Replace('\u000C', ' ') // Form feed
-                .Replace('\u000D', ' ') // Carriage return
+            var normalisedCharacters = s
+                .Select(c =>
+                {
+                    if (char.IsWhiteSpace(c))
+                    {
+                        return ' ';
+                    }
 
-                // Unicode space separators
-                .Replace('\u00A0', ' ') // No-break space
-                .Replace('\u1680', ' ') // Ogham space mark
-                .Replace('\u2000', ' ') // En quad
-                .Replace('\u2001', ' ') // Em quad
-                .Replace('\u2002', ' ') // En space
-                .Replace('\u2003', ' ') // Em space
-                .Replace('\u2004', ' ') // Three-per-em space
-                .Replace('\u2005', ' ') // Four-per-em space
-                .Replace('\u2006', ' ') // Six-per-em space
-                .Replace('\u2007', ' ') // Figure space
-                .Replace('\u2008', ' ') // Punctuation space
-                .Replace('\u2009', ' ') // Thin space
-                .Replace('\u200A', ' ') // Hair space
-                .Replace('\u2028', ' ') // Line separator
-                .Replace('\u2029', ' ') // Paragraph separator
-                .Replace('\u202F', ' ') // Narrow no-break space
-                .Replace('\u205F', ' ') // Medium mathematical space
-                .Replace('\u3000', ' ') // Ideographic space
+                    return c switch
+                    {
+                        // Zero-width/invisible formatting characters
+                        '\u200B' => '\0', // Zero-width space / ZWSP
+                        '\u200C' => '\0', // Zero-width non-joiner
+                        '\u200D' => '\0', // Zero-width joiner
+                        '\u2060' => '\0', // Word joiner
+                        '\uFEFF' => '\0', // Zero-width no-break space / byte order mark
 
-                // Zero-width/invisible formatting characters
-                .Replace("\u200B", "") // Zero-width space / ZWSP
-                .Replace("\u200C", "") // Zero-width non-joiner
-                .Replace("\u200D", "") // Zero-width joiner
-                .Replace("\u2060", "") // Word joiner
-                .Replace("\uFEFF", "") // Zero-width no-break space / byte order mark
+                        // Apostrophe/single quote variants
+                        '\u2018' => '\'', // Left single quotation mark
+                        '\u2019' => '\'', // Right single quotation mark / curly apostrophe
+                        '\u201A' => '\'', // Single low-9 quotation mark
+                        '\u201B' => '\'', // Single high-reversed-9 quotation mark
+                        '\u2032' => '\'', // Prime
+                        '\uFF07' => '\'', // Fullwidth apostrophe
 
-                // Apostrophe/single quote variants
-                .Replace('\u2018', '\'') // Left single quotation mark
-                .Replace('\u2019', '\'') // Right single quotation mark / curly apostrophe
-                .Replace('\u201A', '\'') // Single low-9 quotation mark
-                .Replace('\u201B', '\'') // Single high-reversed-9 quotation mark
-                .Replace('\u2032', '\'') // Prime
-                .Replace('\uFF07', '\''); // Fullwidth apostrophe
+                        // Hyphen/dash variants
+                        '\u2010' => '-', // Hyphen
+                        '\u2011' => '-', // Non-breaking hyphen
+                        '\u2012' => '-', // Figure dash
+                        '\u2013' => '-', // En dash
+                        '\u2014' => '-', // Em dash
+                        '\u2015' => '-', // Horizontal bar
+                        '\u2212' => '-', // Minus sign
+                        '\uFE58' => '-', // Small em dash
+                        '\uFE63' => '-', // Small hyphen-minus
+                        '\uFF0D' => '-', // Fullwidth hyphen-minus
+
+                        _ => c
+                    };
+                })
+                .Where(c => c != '\0')
+                .ToArray();
 
             return Regex.Replace(
-                s.Trim(),
-                @"\s+",
+                new string(normalisedCharacters).Trim(),
+                @" +",
                 " ",
                 RegexOptions.None,
                 TimeSpan.FromMilliseconds(50));
-        }
-
-        private static bool IsWhitespaceChange(string? newValue, string? oldValue)
-        {
-            return string.Equals(Normalise(newValue), Normalise(oldValue), StringComparison.OrdinalIgnoreCase)
-                   && !string.Equals(newValue ?? "", oldValue ?? "", StringComparison.Ordinal);
         }
     }
 }

--- a/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
@@ -59,31 +59,31 @@ namespace SFA.DAS.AODP.Jobs.Services
 
             var fields = new List<string>();
 
-            fields = fields.AppendIf(newRecord.Ssa != qualificationVersion.Ssa, "Ssa");
-            fields = fields.AppendIf(newRecord.Pathways != qualificationVersion.Pathways, "Pathways");
-            fields = fields.AppendIf(newRecord.Status != qualificationVersion.Status, "Status");
+            fields = fields.AppendIf(Normalise(newRecord.Ssa) != Normalise(qualificationVersion.Ssa), "Ssa");
+            fields = fields.AppendIf(Normalise(newRecord.Pathways) != Normalise(qualificationVersion.Pathways), "Pathways");
+            fields = fields.AppendIf(Normalise(newRecord.Status) != Normalise(qualificationVersion.Status), "Status");
             fields = fields.AppendIf(newRecord.SsaId != qualificationVersion.SsaId, "SsaId");
             fields = fields.AppendIf(newRecord.AppearsOnPublicRegister != qualificationVersion.AppearsOnPublicRegister, "AppearsOnPublicRegister");
-            fields = fields.AppendIf(newRecord.ApprenticeshipStandardReferenceNumber != qualificationVersion.ApprenticeshipStandardReferenceNumber, "ApprenticeshipStandardReferenceNumber");
-            fields = fields.AppendIf(newRecord.ApprenticeshipStandardTitle != qualificationVersion.ApprenticeshipStandardTitle, "ApprenticeshipStandardTitle");
+            fields = fields.AppendIf(Normalise(newRecord.ApprenticeshipStandardReferenceNumber) != Normalise(qualificationVersion.ApprenticeshipStandardReferenceNumber), "ApprenticeshipStandardReferenceNumber");
+            fields = fields.AppendIf(Normalise(newRecord.ApprenticeshipStandardTitle) != Normalise(qualificationVersion.ApprenticeshipStandardTitle), "ApprenticeshipStandardTitle");
             fields = fields.AppendIf(NormaliseBoolean(newRecord.ApprovedForDelfundedProgramme, treatFalseAsNull: true) != NormaliseBoolean(qualificationVersion.ApprovedForDelFundedProgramme, treatFalseAsNull: true), "ApprovedForDelfundedProgramme");
             fields = fields.AppendIf(NormaliseDate(newRecord.CertificationEndDate) != NormaliseDate(qualificationVersion.CertificationEndDate), "CertificationEndDate");
             fields = fields.AppendIf(newRecord.EighteenPlus != qualificationVersion.EighteenPlus, "EighteenPlus");
-            fields = fields.AppendIf(newRecord.EntitlementFrameworkDesignation != qualificationVersion.EntitlementFrameworkDesign, "EntitlementFrameworkDesignation");
-            fields = fields.AppendIf(newRecord.EqfLevel != qualificationVersion.EqfLevel, "EqfLevel");
-            fields = fields.AppendIf(newRecord.GceSizeEquivalence != qualificationVersion.GceSizeEquivelence, "GceSizeEquivalence");
-            fields = fields.AppendIf(newRecord.GcseSizeEquivalence != qualificationVersion.GcseSizeEquivelence, "GcseSizeEquivelence");
+            fields = fields.AppendIf(Normalise(newRecord.EntitlementFrameworkDesignation) != Normalise(qualificationVersion.EntitlementFrameworkDesign), "EntitlementFrameworkDesignation");
+            fields = fields.AppendIf(Normalise(newRecord.EqfLevel) != Normalise(qualificationVersion.EqfLevel), "EqfLevel");
+            fields = fields.AppendIf(Normalise(newRecord.GceSizeEquivalence) != Normalise(qualificationVersion.GceSizeEquivelence), "GceSizeEquivalence");
+            fields = fields.AppendIf(Normalise(newRecord.GcseSizeEquivalence) != Normalise(qualificationVersion.GcseSizeEquivelence), "GcseSizeEquivelence");
             fields = fields.AppendIf(newRecord.Glh != qualificationVersion.Glh, "Glh");
-            fields = fields.AppendIf(newRecord.GradingScale != qualificationVersion.GradingScale, "GradingScale");
-            fields = fields.AppendIf(newRecord.GradingType != qualificationVersion.GradingType, "GradingType");
-            fields = fields.AppendIf(newRecord.ImportStatus != qualificationVersion.ImportStatus, "ImportStatus");
+            fields = fields.AppendIf(Normalise(newRecord.GradingScale) != Normalise(qualificationVersion.GradingScale), "GradingScale");
+            fields = fields.AppendIf(Normalise(newRecord.GradingType) != Normalise(qualificationVersion.GradingType), "GradingType");
+            fields = fields.AppendIf(Normalise(newRecord.ImportStatus) != Normalise(qualificationVersion.ImportStatus), "ImportStatus");
             fields = fields.AppendIf(NormaliseDate(newRecord.InsertedDate) != NormaliseDate(qualificationVersion.InsertedDate), "InsertedDate");
             fields = fields.AppendIf(NormaliseDate(newRecord.LastUpdatedDate) != NormaliseDate(qualificationVersion.LastUpdatedDate), "LastUpdatedDate");
-            fields = fields.AppendIf(newRecord.Level != qualificationVersion.Level, "Level");
-            fields = fields.AppendIf(newRecord.LinkToSpecification != qualificationVersion.LinkToSpecification, "LinkToSpecification");
+            fields = fields.AppendIf(Normalise(newRecord.Level) != Normalise(qualificationVersion.Level), "Level");
+            fields = fields.AppendIf(Normalise(newRecord.LinkToSpecification) != Normalise(qualificationVersion.LinkToSpecification), "LinkToSpecification");
             fields = fields.AppendIf(newRecord.MaximumGlh != qualificationVersion.MaximumGlh, "MaximumGlh");
             fields = fields.AppendIf(newRecord.MinimumGlh != qualificationVersion.MinimumGlh, "MinimumGlh");
-            fields = fields.AppendIf(newRecord.NiDiscountCode != qualificationVersion.NiDiscountCode, "NiDiscountCode");
+            fields = fields.AppendIf(Normalise(newRecord.NiDiscountCode) != Normalise(qualificationVersion.NiDiscountCode), "NiDiscountCode");
             fields = fields.AppendIf(newRecord.NineteenPlus != qualificationVersion.NineteenPlus, "NineteenPlus");
             fields = fields.AppendIf(newRecord.OfferedInEngland != qualificationVersion.OfferedInEngland, "OfferedInEngland");
             fields = fields.AppendIf(newRecord.OfferedInNorthernIreland != qualificationVersion.OfferedInNi, "OfferedInNorthernIreland");
@@ -91,25 +91,24 @@ namespace SFA.DAS.AODP.Jobs.Services
             fields = fields.AppendIf(NormaliseDate(newRecord.OperationalEndDate) != NormaliseDate(qualificationVersion.OperationalEndDate), "OperationalEndDate");
             fields = fields.AppendIf(NormaliseDate(newRecord.OperationalStartDate) != NormaliseDate(qualificationVersion.OperationalStartDate), "OperationalStartDate");
 
-            fields = fields.AppendIf(newRecord.OrganisationAcronym != awardingOrganisation.Acronym, "OrganisationAcronym");
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.OrganisationAcronym), Normalise(awardingOrganisation.Acronym), StringComparison.OrdinalIgnoreCase), "OrganisationAcronym");
             fields = fields.AppendIf(!string.Equals(Normalise(newRecord.OrganisationName), Normalise(awardingOrganisation.NameOfqual), StringComparison.OrdinalIgnoreCase), "OrganisationName");
             fields = fields.AppendIf(newRecord.OrganisationId != awardingOrganisation.Ukprn, "OrganisationId");
-            fields = fields.AppendIf(newRecord.OrganisationRecognitionNumber != awardingOrganisation.RecognitionNumber, "OrganisationRecognitionNumber");
+            fields = fields.AppendIf(Normalise(newRecord.OrganisationRecognitionNumber) != Normalise(awardingOrganisation.RecognitionNumber), "OrganisationRecognitionNumber");
 
-            fields = fields.AppendIf(newRecord.Pathways != qualificationVersion.Pathways, "Pathways");
             fields = fields.AppendIf(newRecord.PreSixteen != qualificationVersion.PreSixteen, "PreSixteen");
 
-            fields = fields.AppendIf(newRecord.QualificationNumberNoObliques != qualification.Qan, "QualificationNumberNoObliques");
+            fields = fields.AppendIf(Normalise(newRecord.QualificationNumberNoObliques) != Normalise(qualification.Qan), "QualificationNumberNoObliques");
             fields = fields.AppendIf(newRecord.RegulatedByNorthernIreland != qualificationVersion.RegulatedByNorthernIreland, "RegulatedByNorthernIreland");
             fields = fields.AppendIf(NormaliseDate(newRecord.RegulationStartDate) != NormaliseDate(qualificationVersion.RegulationStartDate), "RegulationStartDate");
             fields = fields.AppendIf(NormaliseDate(newRecord.ReviewDate) != NormaliseDate(qualificationVersion.ReviewDate), "ReviewDate");
             fields = fields.AppendIf(newRecord.SixteenToEighteen != qualificationVersion.SixteenToEighteen, "SixteenToEighteen");
-            fields = fields.AppendIf(newRecord.Specialism != qualificationVersion.Specialism, "Specialism");
-            fields = fields.AppendIf(newRecord.SubLevel != qualificationVersion.SubLevel, "SubLevel");
+            fields = fields.AppendIf(Normalise(newRecord.Specialism) != Normalise(qualificationVersion.Specialism), "Specialism");
+            fields = fields.AppendIf(Normalise(newRecord.SubLevel) != Normalise(qualificationVersion.SubLevel), "SubLevel");
             fields = fields.AppendIf(!string.Equals(Normalise(newRecord.Title), Normalise(qualification.QualificationName), StringComparison.OrdinalIgnoreCase), "Title");
             fields = fields.AppendIf(newRecord.TotalCredits != qualificationVersion.TotalCredits, "TotalCredits");
             fields = fields.AppendIf(newRecord.Tqt != qualificationVersion.Tqt, "Tqt");
-            fields = fields.AppendIf(newRecord.Type != qualificationVersion.Type, "Type");
+            fields = fields.AppendIf(Normalise(newRecord.Type) != Normalise(qualificationVersion.Type), "Type");
             fields = fields.AppendIf(newRecord.TypeId != qualificationVersion.TypeId, "Type");
             fields = fields.AppendIf(NormaliseDate(newRecord.UiLastUpdatedDate) != NormaliseDate(qualificationVersion.UiLastUpdatedDate), "UiLastUpdatedDate");
             fields = fields.AppendIf(newRecord.IntentionToSeekFundingInEngland != qualificationVersion.IntentionToSeekFundingInEngland, "IntentionToSeekFundingInEngland");

--- a/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
@@ -1,18 +1,8 @@
 ﻿using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using RestEase;
-using SFA.DAS.AODP.Common.Enum;
 using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Infrastructure.Context;
-using SFA.DAS.AODP.Infrastructure.Interfaces;
-using SFA.DAS.AODP.Jobs.Client;
-using SFA.DAS.AODP.Jobs.Interfaces;
 using SFA.DAS.AODP.Jobs.Models;
 using SFA.DAS.AODP.Models.Qualification;
-using System.Diagnostics;
 using System.Text.Json;
 using static SFA.DAS.AODP.Jobs.Services.ChangeDetectionService;
 
@@ -335,7 +325,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                                 processStatusName = Common.Enum.ProcessStatus.NoActionRequired;
                                 lifecycleStageName = LifeCycleStage.Completed;
                                 actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
-                                notes = "Completed - No Action required - Changed Qualification (Funding Criteria)";
+                                notes = "No Action required - Completed Qualification (Funding Criteria)";
                             }
                             else
                             {
@@ -356,7 +346,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                                     {
                                         // Minor changes: keep current status but mark as Completed with no action required
                                         processStatusName = currentQualificationVersion.ProcessStatus.Name;
-                                        notes = "Decision Required - Changed Qualification (Minor Fields)";
+                                        notes = $"{processStatusName} - Completed Qualification (Minor Fields)";
                                         lifecycleStageName = LifeCycleStage.Completed;
                                         actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
                                     }
@@ -387,7 +377,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                                     processStatusName = Common.Enum.ProcessStatus.NoActionRequired;
                                     lifecycleStageName = LifeCycleStage.Completed;
                                     actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
-                                    notes = "Completed - No Action required - Changed Qualification (Funding Criteria)";
+                                    notes = "No Action Required - Completed Qualification (Funding Criteria)";
                                 }
                             }
 

--- a/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/OfqualImportService.cs
@@ -204,7 +204,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                         }
                         else
                         { 
-                            organisationId = organisationCache[importRecord.OrganisationId ?? 0]; 
+                            organisationId = organisationCache[importRecord.OrganisationId ?? 0];
                         }
 
                         // Check Qualification
@@ -239,6 +239,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                             var actionTypeId = Guid.Empty;
 
                             var eligibleForFunding = _fundingEligibilityService.EligibleForFunding(importRecord);
+                            var lifecycleStage = LifeCycleStage.New;
 
                             if (eligibleForFunding)
                             {
@@ -246,15 +247,17 @@ namespace SFA.DAS.AODP.Jobs.Services
 
                                 processStatusName = Common.Enum.ProcessStatus.DecisionRequired;
                                 actionTypeId = _actionTypeService.GetActionTypeId(ActionTypeEnum.ActionRequired);
-                                notes = ImportReason.DecisionRequired;                                
+                                notes = ImportReason.DecisionRequired;
+                                lifecycleStage = LifeCycleStage.New;
                             }
                             else
                             {
-                                // Ineligible for funding - No Action Required                                
+                                // Ineligible for funding - mark as Completed (no action)
 
                                 processStatusName = Common.Enum.ProcessStatus.NoActionRequired;
                                 actionTypeId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
-                                notes = _fundingEligibilityService.DetermineFailureReason(importRecord);                                
+                                notes = _fundingEligibilityService.DetermineFailureReason(importRecord);
+                                lifecycleStage = LifeCycleStage.Completed;
                             }
 
                             var versionFieldChange = new VersionFieldChanges
@@ -263,8 +266,7 @@ namespace SFA.DAS.AODP.Jobs.Services
                                 QualificationVersionNumber = 1,
                                 ChangedFieldNames = null
                             };
-                            
-                            var lifecycleStage = LifeCycleStage.New;
+
 
                             var discussionHistory = new QualificationDiscussionHistory
                             {
@@ -300,6 +302,8 @@ namespace SFA.DAS.AODP.Jobs.Services
 
                             // check for changed fields
                             var currentQualificationDto = new QualificationDTO();
+
+                            // TODO[HS]: do we really need to load it up again? We already load the existing versions in memmory so we dont need to go back to the db again.
                             var currentQualificationVersion = _applicationDbContext.QualificationVersions
                                                                 .Include(i => i.Qualification)
                                                                 .Include(i => i.Organisation)
@@ -326,12 +330,12 @@ namespace SFA.DAS.AODP.Jobs.Services
                             var eligibleForFunding = _fundingEligibilityService.EligibleForFunding(importRecord);
                             if (!eligibleForFunding)
                             {
-                                // Not eligible for funding 
+                                // Not eligible for funding - mark as Completed (no action)
 
                                 processStatusName = Common.Enum.ProcessStatus.NoActionRequired;
-                                lifecycleStageName = LifeCycleStage.Changed;
+                                lifecycleStageName = LifeCycleStage.Completed;
                                 actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
-                                notes = "No Action required - Changed Qualification (Funding Criteria)";
+                                notes = "Completed - No Action required - Changed Qualification (Funding Criteria)";
                             }
                             else
                             {
@@ -345,16 +349,17 @@ namespace SFA.DAS.AODP.Jobs.Services
                                         // Decision required as major changes
                                         processStatusName = Common.Enum.ProcessStatus.DecisionRequired;
                                         notes = "Decision Required - Changed Qualification (Key Fields)";
+                                        lifecycleStageName = LifeCycleStage.Changed;
+                                        actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.ActionRequired);
                                     }
                                     else
                                     {
-                                        // Keep the current status as only minor changes
+                                        // Minor changes: keep current status but mark as Completed with no action required
                                         processStatusName = currentQualificationVersion.ProcessStatus.Name;
                                         notes = "Decision Required - Changed Qualification (Minor Fields)";
+                                        lifecycleStageName = LifeCycleStage.Completed;
+                                        actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
                                     }
-
-                                    lifecycleStageName = LifeCycleStage.Changed;
-                                    actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.ActionRequired);                                    
                                 }
                                 else if ((currentQualificationVersion.ProcessStatus.Name == Common.Enum.ProcessStatus.OnHold) ||
                                         (currentQualificationVersion.ProcessStatus.Name == Common.Enum.ProcessStatus.DecisionRequired))
@@ -378,9 +383,11 @@ namespace SFA.DAS.AODP.Jobs.Services
                                 }
                                 else
                                 {
-                                    processStatusName = Common.Enum.ProcessStatus.DecisionRequired;
-                                    lifecycleStageName = LifeCycleStage.Changed;
-                                    actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.ActionRequired);                                   
+                                    // For other statuses, treat as completed with no action required
+                                    processStatusName = Common.Enum.ProcessStatus.NoActionRequired;
+                                    lifecycleStageName = LifeCycleStage.Completed;
+                                    actionId = _actionTypeService.GetActionTypeId(ActionTypeEnum.NoActionRequired);
+                                    notes = "Completed - No Action required - Changed Qualification (Funding Criteria)";
                                 }
                             }
 

--- a/src/SFA.DAS.AODP.Jobs/StartupExtensions/DataImportServiceExtensions.cs
+++ b/src/SFA.DAS.AODP.Jobs/StartupExtensions/DataImportServiceExtensions.cs
@@ -1,4 +1,5 @@
-﻿using SFA.DAS.AODP.Infrastructure.Authentication;
+﻿using Azure.Core;
+using SFA.DAS.AODP.Infrastructure.Authentication;
 
 namespace SFA.DAS.AODP.Jobs.StartupExtensions;
 


### PR DESCRIPTION
- Added in better more robust normalisation to ensure the data discrepancies between our seeding data and the API data doesnt cause unnecessary changed records where it is only a unicode character point change and not a real material change.
- Tightened up rules around how we set Lifecycle and process status for when we detect changes and for whether it is a eligible qualification