### PR TITLE
[AWARD-1225] - Added in import fixes to better handle data discrepancies

### DIFF
--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/LifeCycleStage.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/LifeCycleStage.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SFA.DAS.AODP.Common.Enum
+﻿namespace SFA.DAS.AODP.Common.Enum
 {
     public static class LifeCycleStage
     {
         public const string New = "New";
+        public const string Completed = "Completed";
         public const string Changed = "Changed";
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/ChangeDetectionServiceTests.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
-using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Jobs.Services;
-using SFA.DAS.AODP.Models.Qualification;
-using Xunit;
+﻿using SFA.DAS.AODP.Models.Qualification;
+using Shouldly;
 
 namespace SFA.DAS.AODP.Jobs.Test.Application.Services
 {
@@ -35,9 +32,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(qualificationDTO, qualificationVersion);
 
             // Assert
-            Assert.False(result.ChangesPresent);
-            Assert.Empty(result.ChangedFields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(false);
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBe(false);
         }
 
         [Fact]
@@ -54,9 +51,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(qualificationDTO, qualificationVersion);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Status", result.ChangedFields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(true);
+            result.ChangedFields.ShouldContain("Status");
+            result.KeyFieldsChanged.ShouldBe(false);
         }
 
         [Fact]
@@ -73,9 +70,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(qualificationDTO,qualificationVersion);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Level", result.ChangedFields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(true);
+            result.ChangedFields.ShouldContain("Level");
+            result.KeyFieldsChanged.ShouldBe(true);
         }
 
         [Fact]
@@ -95,20 +92,11 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Level", result.ChangedFields);
-            Assert.Contains("Tqt", result.ChangedFields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(true);
+            result.ChangedFields.ShouldContain("Level");
+            result.ChangedFields.ShouldContain("Tqt");
+            result.KeyFieldsChanged.ShouldBe(true);
         }
-
-        public static IEnumerable<object[]> TitleWhitespaceCases =>
-            new List<object[]>
-            {
-                new object[] { "My Qualification Title", "My  Qualification   Title" },
-                new object[] { "My Qualification Title", " My Qualification Title " },
-                new object[] { "My Qualification Title", "My Qualification Title\n" },
-                new object[] { "My Qualification Title", "My Qualification Title\u00A0" }
-            };
 
         [Theory]
         [MemberData(nameof(TitleWhitespaceCases))]
@@ -127,9 +115,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(qualificationDTO, qualificationVersion);
 
             // Assert
-            Assert.False(result.ChangesPresent);
-            Assert.Empty(result.ChangedFields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(false);
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBe(false);
         }
 
         [Fact]
@@ -146,9 +134,9 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(qualificationDTO, qualificationVersion);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.Contains("Title", result.ChangedFields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(true);
+            result.ChangedFields.ShouldContain("Title");
+            result.KeyFieldsChanged.ShouldBe(true);
         }
 
         [Fact]
@@ -168,10 +156,10 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version);
 
             // Assert
-            Assert.True(result.ChangesPresent);
-            Assert.DoesNotContain("Title", result.ChangedFields);   
-            Assert.Contains("Level", result.ChangedFields);
-            Assert.True(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(true);
+            result.ChangedFields.ShouldNotContain("Title");
+            result.ChangedFields.ShouldContain("Level");
+            result.KeyFieldsChanged.ShouldBe(true);
         }
 
         [Fact]
@@ -188,10 +176,192 @@ namespace SFA.DAS.AODP.Jobs.Test.Application.Services
             var result = sut.DetectChanges(dto, version);
 
             // Assert
-            Assert.False(result.ChangesPresent);
-            Assert.Empty(result.ChangedFields);
-            Assert.False(result.KeyFieldsChanged);
+            result.ChangesPresent.ShouldBe(false);
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBe(false);
         }
 
+        [Fact]
+        public void DetectChanges_ApprovedForDelFundedProgramme_FalseTreatedAsNull_NoChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            dto.ApprovedForDelfundedProgramme = "false"; // treated as null
+            version.ApprovedForDelFundedProgramme = null;
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_ApprovedForDelFundedProgramme_True_IsChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            dto.ApprovedForDelfundedProgramme = "true";
+            version.ApprovedForDelFundedProgramme = null;
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            result.ChangesPresent.ShouldBeTrue();
+            result.ChangedFields.ShouldContain("ApprovedForDelfundedProgramme");
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_LastUpdatedDate_TimeOfDayDifferences_AreIgnored()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            dto.LastUpdatedDate = new DateTime(2024, 1, 1, 13, 30, 0);
+            version.LastUpdatedDate = new DateTime(2024, 1, 1, 0, 0, 0);
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.ChangedFields.ShouldNotContain("LastUpdatedDate");
+        }
+
+        [Fact]
+        public void DetectChanges_OrganisationName_WithUnicodeAndZeroWidth_AreNormalised_NoChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            dto.OrganisationName = "O'Connor";
+            version.Organisation.NameOfqual = "O\u2019Connor\u200B"; // curly apostrophe + zero-width space
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            result.ChangesPresent.ShouldBeFalse();
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(HyphenVariantsCases))]
+        public void DetectChanges_HyphenVariants_AreNormalised_NoChange(
+            string oldTitle,
+            string newTitle)
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            version.Qualification.QualificationName = oldTitle;
+            dto.Title = newTitle;
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            // Various unicode hyphen/dash characters should normalise to a simple hyphen and not be treated as changes
+            result.ChangesPresent.ShouldBeFalse();
+            result.ChangedFields.ShouldBeEmpty();
+            result.KeyFieldsChanged.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void DetectChanges_HyphenRemoved_IsKeyChange()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var (dto, version) = CreateEmptyBaseline();
+
+            version.Qualification.QualificationName = "A-B Qualification";
+            dto.Title = "A B Qualification"; // hyphen removed -> treated as meaningful change
+
+            // Act
+            var result = sut.DetectChanges(dto, version);
+
+            // Assert
+            result.ChangesPresent.ShouldBeTrue();
+            result.ChangedFields.ShouldContain("Title");
+            result.KeyFieldsChanged.ShouldBeTrue();
+        }
+
+        #region Theory Data
+
+        public static IEnumerable<object[]> TitleWhitespaceCases =>
+             new List<object[]>
+             {
+                // multiple spaces
+                new object[] { "My Qualification Title", "My  Qualification   Title" },
+                // leading/trailing spaces
+                new object[] { "My Qualification Title", " My Qualification Title " },
+                // newline
+                new object[] { "My Qualification Title", "My Qualification Title\n" },
+                // no-break space
+                new object[] { "My Qualification Title", "My Qualification Title\u00A0" },
+                // tab
+                new object[] { "My Qualification Title", "My\tQualification Title" },
+                // vertical tab and form feed
+                new object[] { "My Qualification Title", "My Qualification\u000B Title" },
+                new object[] { "My Qualification Title", "My Qualification\u000C Title" },
+                // carriage return
+                new object[] { "My Qualification Title", "My Qualification Title\r" },
+                // various unicode space separators
+                new object[] { "My Qualification Title", "My Qualification\u1680 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2003 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2009 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u200A Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2028 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2029 Title" },
+                new object[] { "My Qualification Title", "My Qualification\u202F Title" },
+                new object[] { "My Qualification Title", "My Qualification\u205F Title" },
+                new object[] { "My Qualification Title", "My Qualification\u3000 Title" },
+                // zero-width / invisible characters
+                new object[] { "My Qualification Title", "My\u200B Qualification Title" },
+                new object[] { "My Qualification Title", "My Qualification\u200C Title" },
+                new object[] { "My Qualification Title", "My\u200D Qualification Title" },
+                new object[] { "My Qualification Title", "My Qualification\u2060 Title" },
+                new object[] { "My Qualification Title", "\uFEFFMy Qualification Title" },
+                // apostrophe/quote variants should normalise to straight apostrophe
+                new object[] { "O'Connor", "O\u2019Connor" },
+                new object[] { "O'Connor", "O\u2018Connor" },
+                new object[] { "O'Connor", "O\u201AConnor" },
+                new object[] { "O'Connor", "O\u201BConnor" },
+                new object[] { "O'Connor", "O\u2032Connor" },
+                new object[] { "O'Connor", "O\uFF07Connor" },
+                // case-only change should be treated as non-key (normalisation compares ignoring case)
+                new object[] { "My Qualification Title", "my qualification title" },
+                // mixed invisible and spacing characters
+                new object[] { "My Qualification Title", " My\u200B Qualification\u00A0 Title\u200D " }
+             };
+
+        public static IEnumerable<object[]> HyphenVariantsCases =>
+            new List<object[]>
+            {
+                new object[] { "A-B Qualification", "A\u2010B Qualification" }, // hyphen
+                new object[] { "A-B Qualification", "A\u2011B Qualification" }, // non-breaking hyphen
+                new object[] { "A-B Qualification", "A\u2012B Qualification" }, // figure dash
+                new object[] { "A-B Qualification", "A\u2013B Qualification" }, // en dash
+                new object[] { "A-B Qualification", "A\u2014B Qualification" }, // em dash
+                new object[] { "A-B Qualification", "A\u2015B Qualification" }, // horizontal bar
+                new object[] { "A-B Qualification", "A\u2212B Qualification" }, // minus sign
+                new object[] { "A-B Qualification", "A\uFE58B Qualification" }, // small em dash
+                new object[] { "A-B Qualification", "A\uFE63B Qualification" }, // small hyphen-minus
+                new object[] { "A-B Qualification", "A\uFF0DB Qualification" }  // fullwidth hyphen-minus
+            };
+
+        #endregion
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationProcessorTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/QualificationProcessorTests.cs
@@ -1,9 +1,9 @@
-﻿using SFA.DAS.AODP.Data.Entities;
-using SFA.DAS.AODP.Jobs.Models.Jobs.FundingEligibility;
+﻿using SFA.DAS.AODP.Jobs.Models.Jobs.FundingEligibility;
 using SFA.DAS.AODP.Models.Qualification;
+using Shouldly;
 using static SFA.DAS.AODP.Jobs.Services.ChangeDetectionService;
 
-namespace SFA.DAS.AODP.Jobs.Tests;
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services;
 
 public class QualificationProcessorTests
 {
@@ -58,7 +58,7 @@ public class QualificationProcessorTests
             ? LifecycleStageLookup.New.Id
             : LifecycleStageLookup.Completed.Id;
 
-        Assert.Equal(expectedStage, result.NewVersion.LifecycleStageId);
+        result.NewVersion.LifecycleStageId.ShouldBe(expectedStage);
     }
 
     [Theory]
@@ -102,12 +102,12 @@ public class QualificationProcessorTests
         var result = _processor.Process(new QualificationDTO(), existingVersion, Guid.NewGuid(), Guid.NewGuid(), hasApps, hasFunding);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(expectedStatusId, result.NewVersion.ProcessStatusId);
+        result.ShouldNotBeNull();
+        result.NewVersion.ProcessStatusId.ShouldBe(expectedStatusId);
 
         if (expectDecisionRequired)
         {
-            Assert.NotNull(result.FieldChange.ChangedFieldNames);
+            result.FieldChange.ChangedFieldNames.ShouldNotBeNull();
         }
     }
 
@@ -153,8 +153,8 @@ public class QualificationProcessorTests
         var result = _processor.Process(new QualificationDTO(), existingVersion, Guid.NewGuid(), Guid.NewGuid(), false, false);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(expectedStatusId, result.NewVersion.ProcessStatusId);
+        result.ShouldNotBeNull();
+        result.NewVersion.ProcessStatusId.ShouldBe(expectedStatusId);
     }
 
     [Theory]
@@ -191,13 +191,13 @@ public class QualificationProcessorTests
         var result = _processor.Process(new QualificationDTO(), existingVersion, existingVersion.QualificationId, Guid.NewGuid(), false, false);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(statusId, result.NewVersion.ProcessStatusId);
-        Assert.Contains(expectedNoteWord, result.Discussion.Notes);
+        result.ShouldNotBeNull();
+        result.NewVersion.ProcessStatusId.ShouldBe(statusId);
+        result.Discussion.Notes!.ShouldContain(expectedNoteWord);
     }
 
     [Fact]
-    public void Process_UnknownStatus_DefaultsToDecisionRequired()
+    public void Process_UnknownStatus_DefaultsToNoActionRequired()
     {
         // Arrange
         var existingVersion = new QualificationVersions
@@ -216,8 +216,8 @@ public class QualificationProcessorTests
         var result = _processor.Process(new QualificationDTO(), existingVersion, Guid.NewGuid(), Guid.NewGuid(), false, false);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(ProcessStatusLookup.DecisionRequired.Id, result.NewVersion.ProcessStatusId);
-        Assert.Contains("decision required - changed qualification", result.Discussion.Notes);
+        result.ShouldNotBeNull();
+        result.NewVersion.ProcessStatusId.ShouldBe(ProcessStatusLookup.NoActionRequired.Id);
+        result.Discussion.Notes!.ShouldContain("no action required - changed qualification");
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/ChangeDetectionService.cs
@@ -47,8 +47,6 @@ namespace SFA.DAS.AODP.Jobs.Services
                     "MinimumGLH",
                     "Tqt",
                     "OperationalEndDate",
-                    "LastUpdatedDate",
-                    "Version", //internal version numbers do not match Ofqual version numbers (we start from 1)
                     "OfferedInternationally"
                 };
         }
@@ -60,65 +58,67 @@ namespace SFA.DAS.AODP.Jobs.Services
 
             // Could use Reflection here, but records being compared have mismatched names, different field types, or information located in other structures
 
-            var fields = new List<string>();       
-            fields = fields.AppendIf(newRecord.Ssa != qualificationVersion.Ssa, "Ssa");
-            fields = fields.AppendIf(newRecord.Pathways != qualificationVersion.Pathways, "Pathways");
-            fields = fields.AppendIf(newRecord.Status != qualificationVersion.Status, "Status");
+            var fields = new List<string>();
+
+            fields = fields.AppendIf(Normalise(newRecord.Ssa) != Normalise(qualificationVersion.Ssa), "Ssa");
+            fields = fields.AppendIf(Normalise(newRecord.Pathways) != Normalise(qualificationVersion.Pathways), "Pathways");
+            fields = fields.AppendIf(Normalise(newRecord.Status) != Normalise(qualificationVersion.Status), "Status");
             fields = fields.AppendIf(newRecord.SsaId != qualificationVersion.SsaId, "SsaId");
             fields = fields.AppendIf(newRecord.AppearsOnPublicRegister != qualificationVersion.AppearsOnPublicRegister, "AppearsOnPublicRegister");
-            fields = fields.AppendIf(newRecord.ApprenticeshipStandardReferenceNumber != qualificationVersion.ApprenticeshipStandardReferenceNumber, "ApprenticeshipStandardReferenceNumber");
-            fields = fields.AppendIf(newRecord.ApprenticeshipStandardTitle != qualificationVersion.ApprenticeshipStandardTitle, "ApprenticeshipStandardTitle");
-            fields = fields.AppendIf(newRecord.ApprovedForDelfundedProgramme != qualificationVersion.ApprovedForDelFundedProgramme, "ApprovedForDelfundedProgramme");
-            fields = fields.AppendIf(newRecord.CertificationEndDate != qualificationVersion.CertificationEndDate, "CertificationEndDate");
+            fields = fields.AppendIf(Normalise(newRecord.ApprenticeshipStandardReferenceNumber) != Normalise(qualificationVersion.ApprenticeshipStandardReferenceNumber), "ApprenticeshipStandardReferenceNumber");
+            fields = fields.AppendIf(Normalise(newRecord.ApprenticeshipStandardTitle) != Normalise(qualificationVersion.ApprenticeshipStandardTitle), "ApprenticeshipStandardTitle");
+            fields = fields.AppendIf(NormaliseBoolean(newRecord.ApprovedForDelfundedProgramme, treatFalseAsNull: true) != NormaliseBoolean(qualificationVersion.ApprovedForDelFundedProgramme, treatFalseAsNull: true), "ApprovedForDelfundedProgramme");
+            fields = fields.AppendIf(NormaliseDate(newRecord.CertificationEndDate) != NormaliseDate(qualificationVersion.CertificationEndDate), "CertificationEndDate");
             fields = fields.AppendIf(newRecord.EighteenPlus != qualificationVersion.EighteenPlus, "EighteenPlus");
-            fields = fields.AppendIf(newRecord.EntitlementFrameworkDesignation != qualificationVersion.EntitlementFrameworkDesign, "EntitlementFrameworkDesignation");
-            fields = fields.AppendIf(newRecord.EqfLevel != qualificationVersion.EqfLevel, "EqfLevel");
-            fields = fields.AppendIf(newRecord.GceSizeEquivalence != qualificationVersion.GceSizeEquivelence, "GceSizeEquivalence");
-            fields = fields.AppendIf(newRecord.GcseSizeEquivalence != qualificationVersion.GcseSizeEquivelence, "GcseSizeEquivelence");
+            fields = fields.AppendIf(Normalise(newRecord.EntitlementFrameworkDesignation) != Normalise(qualificationVersion.EntitlementFrameworkDesign), "EntitlementFrameworkDesignation");
+            fields = fields.AppendIf(Normalise(newRecord.EqfLevel) != Normalise(qualificationVersion.EqfLevel), "EqfLevel");
+            fields = fields.AppendIf(Normalise(newRecord.GceSizeEquivalence) != Normalise(qualificationVersion.GceSizeEquivelence), "GceSizeEquivalence");
+            fields = fields.AppendIf(Normalise(newRecord.GcseSizeEquivalence) != Normalise(qualificationVersion.GcseSizeEquivelence), "GcseSizeEquivelence");
             fields = fields.AppendIf(newRecord.Glh != qualificationVersion.Glh, "Glh");
-            fields = fields.AppendIf(newRecord.GradingScale != qualificationVersion.GradingScale, "GradingScale");
-            fields = fields.AppendIf(newRecord.GradingType != qualificationVersion.GradingType, "GradingType");
-            fields = fields.AppendIf(newRecord.ImportStatus != qualificationVersion.ImportStatus, "ImportStatus");
-            fields = fields.AppendIf(newRecord.InsertedDate != qualificationVersion.InsertedDate, "InsertedDate");
-            fields = fields.AppendIf(newRecord.LastUpdatedDate != qualificationVersion.LastUpdatedDate, "LastUpdatedDate");
-            fields = fields.AppendIf(newRecord.Level != qualificationVersion.Level, "Level");
-            fields = fields.AppendIf(newRecord.LinkToSpecification != qualificationVersion.LinkToSpecification, "LinkToSpecification");
+            fields = fields.AppendIf(Normalise(newRecord.GradingScale) != Normalise(qualificationVersion.GradingScale), "GradingScale");
+            fields = fields.AppendIf(Normalise(newRecord.GradingType) != Normalise(qualificationVersion.GradingType), "GradingType");
+            fields = fields.AppendIf(Normalise(newRecord.ImportStatus) != Normalise(qualificationVersion.ImportStatus), "ImportStatus");
+            fields = fields.AppendIf(NormaliseDate(newRecord.InsertedDate) != NormaliseDate(qualificationVersion.InsertedDate), "InsertedDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.LastUpdatedDate) != NormaliseDate(qualificationVersion.LastUpdatedDate), "LastUpdatedDate");
+            fields = fields.AppendIf(Normalise(newRecord.Level) != Normalise(qualificationVersion.Level), "Level");
+            fields = fields.AppendIf(Normalise(newRecord.LinkToSpecification) != Normalise(qualificationVersion.LinkToSpecification), "LinkToSpecification");
             fields = fields.AppendIf(newRecord.MaximumGlh != qualificationVersion.MaximumGlh, "MaximumGlh");
             fields = fields.AppendIf(newRecord.MinimumGlh != qualificationVersion.MinimumGlh, "MinimumGlh");
-            fields = fields.AppendIf(newRecord.NiDiscountCode != qualificationVersion.NiDiscountCode, "NiDiscountCode");
+            fields = fields.AppendIf(Normalise(newRecord.NiDiscountCode) != Normalise(qualificationVersion.NiDiscountCode), "NiDiscountCode");
             fields = fields.AppendIf(newRecord.NineteenPlus != qualificationVersion.NineteenPlus, "NineteenPlus");
             fields = fields.AppendIf(newRecord.OfferedInEngland != qualificationVersion.OfferedInEngland, "OfferedInEngland");
             fields = fields.AppendIf(newRecord.OfferedInNorthernIreland != qualificationVersion.OfferedInNi, "OfferedInNorthernIreland");
             fields = fields.AppendIf(newRecord.OfferedInternationally != qualificationVersion.OfferedInternationally, "OfferedInternationally");
-            fields = fields.AppendIf(newRecord.OperationalEndDate != qualificationVersion.OperationalEndDate, "OperationalEndDate");
-            fields = fields.AppendIf(newRecord.OperationalStartDate != qualificationVersion.OperationalStartDate, "OperationalStartDate");
-          
-            fields = fields.AppendIf(newRecord.OrganisationAcronym != awardingOrganisation.Acronym, "OrganisationAcronym");
-            fields = fields.AppendIf(newRecord.OrganisationName != awardingOrganisation.NameOfqual, "OrganisationName");
+            fields = fields.AppendIf(NormaliseDate(newRecord.OperationalEndDate) != NormaliseDate(qualificationVersion.OperationalEndDate), "OperationalEndDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.OperationalStartDate) != NormaliseDate(qualificationVersion.OperationalStartDate), "OperationalStartDate");
+
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.OrganisationAcronym), Normalise(awardingOrganisation.Acronym), StringComparison.OrdinalIgnoreCase), "OrganisationAcronym");
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.OrganisationName), Normalise(awardingOrganisation.NameOfqual), StringComparison.OrdinalIgnoreCase), "OrganisationName");
             fields = fields.AppendIf(newRecord.OrganisationId != awardingOrganisation.Ukprn, "OrganisationId");
-            fields = fields.AppendIf(newRecord.OrganisationRecognitionNumber != awardingOrganisation.RecognitionNumber, "OrganisationRecognitionNumber");
+            fields = fields.AppendIf(Normalise(newRecord.OrganisationRecognitionNumber) != Normalise(awardingOrganisation.RecognitionNumber), "OrganisationRecognitionNumber");
 
             fields = fields.AppendIf(newRecord.PreSixteen != qualificationVersion.PreSixteen, "PreSixteen");
 
-            fields = fields.AppendIf(newRecord.QualificationNumberNoObliques != qualification.Qan, "QualificationNumberNoObliques");
+            fields = fields.AppendIf(Normalise(newRecord.QualificationNumberNoObliques) != Normalise(qualification.Qan), "QualificationNumberNoObliques");
             fields = fields.AppendIf(newRecord.RegulatedByNorthernIreland != qualificationVersion.RegulatedByNorthernIreland, "RegulatedByNorthernIreland");
-            fields = fields.AppendIf(newRecord.RegulationStartDate != qualificationVersion.RegulationStartDate, "RegulationStartDate");
-            fields = fields.AppendIf(newRecord.ReviewDate != qualificationVersion.ReviewDate, "ReviewDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.RegulationStartDate) != NormaliseDate(qualificationVersion.RegulationStartDate), "RegulationStartDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.ReviewDate) != NormaliseDate(qualificationVersion.ReviewDate), "ReviewDate");
             fields = fields.AppendIf(newRecord.SixteenToEighteen != qualificationVersion.SixteenToEighteen, "SixteenToEighteen");
-            fields = fields.AppendIf(newRecord.Specialism != qualificationVersion.Specialism, "Specialism");            
-            fields = fields.AppendIf(newRecord.SubLevel != qualificationVersion.SubLevel, "SubLevel");
-            fields = fields.AppendIf(
-                !IsWhitespaceChange(newRecord.Title, qualification.QualificationName)
-                && newRecord.Title != qualification.QualificationName,
-                "Title");
+            fields = fields.AppendIf(Normalise(newRecord.Specialism) != Normalise(qualificationVersion.Specialism), "Specialism");
+            fields = fields.AppendIf(Normalise(newRecord.SubLevel) != Normalise(qualificationVersion.SubLevel), "SubLevel");
+            fields = fields.AppendIf(!string.Equals(Normalise(newRecord.Title), Normalise(qualification.QualificationName), StringComparison.OrdinalIgnoreCase), "Title");
             fields = fields.AppendIf(newRecord.TotalCredits != qualificationVersion.TotalCredits, "TotalCredits");
             fields = fields.AppendIf(newRecord.Tqt != qualificationVersion.Tqt, "Tqt");
-            fields = fields.AppendIf(newRecord.Type != qualificationVersion.Type, "Type");
+            fields = fields.AppendIf(Normalise(newRecord.Type) != Normalise(qualificationVersion.Type), "Type");
             fields = fields.AppendIf(newRecord.TypeId != qualificationVersion.TypeId, "Type");
-            fields = fields.AppendIf(newRecord.UiLastUpdatedDate != qualificationVersion.UiLastUpdatedDate, "UiLastUpdatedDate");
+            fields = fields.AppendIf(NormaliseDate(newRecord.UiLastUpdatedDate) != NormaliseDate(qualificationVersion.UiLastUpdatedDate), "UiLastUpdatedDate");
             fields = fields.AppendIf(newRecord.IntentionToSeekFundingInEngland != qualificationVersion.IntentionToSeekFundingInEngland, "IntentionToSeekFundingInEngland");
 
-            var results = new DetectionResults() { ChangedFields = fields, ChangesPresent = fields.Count > 0 };
+            var results = new DetectionResults
+            {
+                ChangedFields = fields, 
+                ChangesPresent = fields.Count > 0
+            };
 
             if (results.ChangesPresent)
             {
@@ -129,22 +129,98 @@ namespace SFA.DAS.AODP.Jobs.Services
             return results;
         }
 
-        private static string Normalize(string? s)
+        private static bool? NormaliseBoolean(string? value, bool treatFalseAsNull = false)
         {
-            if (string.IsNullOrWhiteSpace(s)) return string.Empty;
-            s = s.Replace('\u00A0', ' ');              
-            return Regex.Replace(
-                s.Trim(),
-                @"\s+",
-                " ",
-                RegexOptions.None,
-                TimeSpan.FromMilliseconds(50)); 
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            var normalisedValue = value.Trim();
+
+            bool? parsedValue = normalisedValue.ToLowerInvariant() switch
+            {
+                "true" => true,
+                "false" => false,
+
+                "1" => true,
+                "0" => false,
+
+                "yes" => true,
+                "no" => false,
+
+                _ => null
+            };
+
+            if (treatFalseAsNull && parsedValue == false)
+            {
+                return null;
+            }
+
+            return parsedValue;
         }
 
-        private static bool IsWhitespaceChange(string? newValue, string? oldValue)
+        private static DateTime? NormaliseDate(DateTime? date)
         {
-            return string.Equals(Normalize(newValue), Normalize(oldValue), StringComparison.OrdinalIgnoreCase)
-                   && !string.Equals(newValue ?? "", oldValue ?? "", StringComparison.Ordinal);
+            return date?.Date;
+        }
+
+        private static string Normalise(string? s)
+        {
+            if (string.IsNullOrWhiteSpace(s))
+            {
+                return string.Empty;
+            }
+
+            var normalisedCharacters = s
+                .Select(c =>
+                {
+                    if (char.IsWhiteSpace(c))
+                    {
+                        return ' ';
+                    }
+
+                    return c switch
+                    {
+                        // Zero-width/invisible formatting characters
+                        '\u200B' => '\0', // Zero-width space / ZWSP
+                        '\u200C' => '\0', // Zero-width non-joiner
+                        '\u200D' => '\0', // Zero-width joiner
+                        '\u2060' => '\0', // Word joiner
+                        '\uFEFF' => '\0', // Zero-width no-break space / byte order mark
+
+                        // Apostrophe/single quote variants
+                        '\u2018' => '\'', // Left single quotation mark
+                        '\u2019' => '\'', // Right single quotation mark / curly apostrophe
+                        '\u201A' => '\'', // Single low-9 quotation mark
+                        '\u201B' => '\'', // Single high-reversed-9 quotation mark
+                        '\u2032' => '\'', // Prime
+                        '\uFF07' => '\'', // Fullwidth apostrophe
+
+                        // Hyphen/dash variants
+                        '\u2010' => '-', // Hyphen
+                        '\u2011' => '-', // Non-breaking hyphen
+                        '\u2012' => '-', // Figure dash
+                        '\u2013' => '-', // En dash
+                        '\u2014' => '-', // Em dash
+                        '\u2015' => '-', // Horizontal bar
+                        '\u2212' => '-', // Minus sign
+                        '\uFE58' => '-', // Small em dash
+                        '\uFE63' => '-', // Small hyphen-minus
+                        '\uFF0D' => '-', // Fullwidth hyphen-minus
+
+                        _ => c
+                    };
+                })
+                .Where(c => c != '\0')
+                .ToArray();
+
+            return Regex.Replace(
+                new string(normalisedCharacters).Trim(),
+                @" +",
+                " ",
+                RegexOptions.None,
+                TimeSpan.FromMilliseconds(50));
         }
     }
 }

--- a/src/SFA.DAS.AODP.Jobs/Services/QualificationProcessor.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/QualificationProcessor.cs
@@ -169,13 +169,13 @@ namespace SFA.DAS.AODP.Jobs.Services
             }
 
             return new QualificationProcessorOutcome(
-                StatusId: ProcessStatusLookup.DecisionRequired.Id,
-                StageId: LifecycleStageLookup.Changed.Id,
-                ActionId: ActionTypeLookup.ActionRequired.Id,
-                BaseNote: "decision required - changed qualification",
+                StatusId: ProcessStatusLookup.NoActionRequired.Id,
+                StageId: LifecycleStageLookup.Completed.Id,
+                ActionId: ActionTypeLookup.NoActionRequired.Id,
+                BaseNote: "no action required - changed qualification",
                 IncludeFieldChanges: true,
                 IncludeEligibilityReasons: false,
-                ReviewRequired: true,
+                ReviewRequired: requiresRereview,
                 HasFundingWhichHasNotEnded: context.HasFundingWhichHasNotEnded);
         }
 


### PR DESCRIPTION
[AWARD-1225]

- Added in better more robust normalisation to ensure the data discrepancies between our seeding data and the API data doesnt cause unnecessary changed records where it is only a unicode character point change and not a real material change.
- Tightened up rules around how we set Lifecycle and process status for when we detect changes and for whether it is a eligible qualification

[AWARD-1225]: https://skillsfundingagency.atlassian.net/browse/AWARD-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ