### PR TITLE
[AWARD-1078] - Added new scheduled job for rollover candidates

### DIFF
--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/Enums/RolloverStatus.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/Enums/RolloverStatus.cs
@@ -1,0 +1,12 @@
+namespace SFA.DAS.AODP.Data.Entities.Rollover.Enums;
+
+public enum RolloverStatus
+{
+    None = 0,
+    NeedsReview = 1,
+    InProgress = 2,
+    Extended = 3,
+    Rejected = 4,
+    Ignored = 5,
+    Unknown = 99
+}

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidate.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidate.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using SFA.DAS.AODP.Data.Entities.Rollover.Enums;
+
+namespace SFA.DAS.AODP.Data.Entities.Rollover;
+
+[Table("RolloverCandidates", Schema = "dbo")]
+public class RolloverCandidate
+{
+    public Guid Id { get; private set; }
+
+    public Guid QualificationVersionId { get; private set; }
+
+    public Guid FundingOfferId { get; private set; }
+
+    public string AcademicYear { get; private set; } = null!;
+
+    public int RolloverRound { get; private set; }
+
+    public Guid? RolloverDecisionRunId { get; private set; }
+
+    public RolloverStatus RolloverStatus { get; private set; }
+
+    public string? ExclusionReason { get; private set; }
+
+    public DateTime? PreviousFundingEndDate { get; private set; }
+
+    public DateTime? NewFundingEndDate { get; private set; }
+
+    public DateTime? ReviewedAt { get; private set; }
+
+    public string? ReviewedByUsername { get; private set; }
+
+    public bool IsActive { get; private set; }
+
+    public DateTime CreatedAt { get; private set; }
+
+    public DateTime UpdatedAt { get; private set; }
+
+    public virtual QualificationVersions QualificationVersion { get; set; } = null!;
+
+    public virtual FundingOffer FundingOffer { get; set; } = null!;
+
+    public static RolloverCandidate CreateInitialRound(
+        Guid qualificationVersionId,
+        Guid fundingOfferId,
+        string academicYear,
+        DateTime createdAt,
+        DateOnly? previousFundingEndDate)
+    {
+        if (string.IsNullOrWhiteSpace(academicYear))
+        {
+            throw new ArgumentNullException(nameof(academicYear));
+        }
+
+        return new RolloverCandidate
+        {
+            Id = Guid.NewGuid(),
+            QualificationVersionId = qualificationVersionId,
+            FundingOfferId = fundingOfferId,
+            AcademicYear = academicYear,
+            RolloverRound = 1,
+            RolloverStatus = RolloverStatus.NeedsReview,
+            PreviousFundingEndDate = previousFundingEndDate?.ToDateTime(TimeOnly.MinValue),
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            IsActive = true
+        };
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Common/Enum/JobNameEnum.cs
+++ b/src/SFA.DAS.AODP.Jobs.Common/Enum/JobNameEnum.cs
@@ -6,6 +6,7 @@
         FundedQualifications,
         Pldns,
         DefundingList,
-        QaaQualifications
+        QaaQualifications,
+        RolloverCandidates
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Context/ApplicationDbContext.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Context/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Entities;
+using SFA.DAS.AODP.Data.Entities.Rollover;
 
 
 namespace SFA.DAS.AODP.Infrastructure.Context
@@ -48,6 +49,8 @@ namespace SFA.DAS.AODP.Infrastructure.Context
         public virtual DbSet<DefundingList> DefundingLists { get; set; }
         
         public virtual DbSet<RegulatedQaaQualification> RegulatedQaaQualification { get; set; }
+        
+        public virtual DbSet<RolloverCandidate> RolloverCandidates { get; set; }
 
         public virtual void StartingBulkInsert() => ChangeTracker.AutoDetectChangesEnabled = false;
 
@@ -62,6 +65,15 @@ namespace SFA.DAS.AODP.Infrastructure.Context
                 .HasConversion(
                     ssaTier => ssaTier.Name,
                     ssaName => SectorSubjectArea.FromName(ssaName));
+
+            modelBuilder.Entity<RolloverCandidate>(b =>
+            {
+                b.Property(x => x.RolloverStatus)
+                    .HasConversion<string>();
+
+                b.HasIndex(x => new { x.QualificationVersionId, x.FundingOfferId, x.AcademicYear, x.RolloverRound })
+                    .IsUnique();
+            });
         }
 
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Context/IApplicationDbContext.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Context/IApplicationDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using SFA.DAS.AODP.Data.Entities;
+using SFA.DAS.AODP.Data.Entities.Rollover;
 
 namespace SFA.DAS.AODP.Infrastructure.Context
 {
@@ -26,6 +27,7 @@ namespace SFA.DAS.AODP.Infrastructure.Context
         DbSet<Pldns> Pldns { get; set; }
         DbSet<DefundingList> DefundingLists { get; set; }
         DbSet<RegulatedQaaQualification> RegulatedQaaQualification { get; set; }
+        DbSet<RolloverCandidate> RolloverCandidates { get; set; }
 
         void StartingBulkInsert();
 

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationFundingQueryExtensions.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationFundingQueryExtensions.cs
@@ -1,4 +1,5 @@
 using SFA.DAS.AODP.Data.Entities;
+using SFA.DAS.AODP.Infrastructure.Models;
 
 namespace SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
 
@@ -6,8 +7,8 @@ public static class QualificationFundingQueryExtensions
 {
     public static IQueryable<QualificationFunding> WhereActiveForAcademicYear(
         this IQueryable<QualificationFunding> query,
-        DateOnly academicYearEndDate)
+        AcademicYear academicYear)
     {
-        return query.Where(funding => funding.EndDate == null || funding.EndDate == academicYearEndDate);
+        return query.Where(funding => funding.EndDate == null || funding.EndDate >= academicYear.StartDate && funding.EndDate <= academicYear.EndDate);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationFundingQueryExtensions.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationFundingQueryExtensions.cs
@@ -1,0 +1,13 @@
+using SFA.DAS.AODP.Data.Entities;
+
+namespace SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
+
+public static class QualificationFundingQueryExtensions
+{
+    public static IQueryable<QualificationFunding> WhereActiveForAcademicYear(
+        this IQueryable<QualificationFunding> query,
+        DateOnly academicYearEndDate)
+    {
+        return query.Where(funding => funding.EndDate == null || funding.EndDate == academicYearEndDate);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationVersionQueryExtensions.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Extensions/Rollover/QualificationVersionQueryExtensions.cs
@@ -1,0 +1,31 @@
+using SFA.DAS.AODP.Data.Entities;
+
+namespace SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
+
+public static class QualificationVersionQueryExtensions
+{
+    public static IQueryable<QualificationVersions> WhereEligibleForFunding(this IQueryable<QualificationVersions> query)
+    {
+        return query.Where(qualificationVersion => qualificationVersion.EligibleForFunding == true);
+    }
+
+    public static IQueryable<QualificationVersions> WhereLatestVersionPerQualification(
+        this IQueryable<QualificationVersions> query,
+        IQueryable<QualificationVersions> allQualificationVersions)
+    {
+        return query.Where(qualificationVersion => !allQualificationVersions.Any(otherVersion =>
+            otherVersion.QualificationId == qualificationVersion.QualificationId &&
+            (
+                (otherVersion.Version ?? 0) > (qualificationVersion.Version ?? 0) ||
+                (
+                    (otherVersion.Version ?? 0) == (qualificationVersion.Version ?? 0) &&
+                    otherVersion.LastUpdatedDate > qualificationVersion.LastUpdatedDate
+                ) ||
+                (
+                    (otherVersion.Version ?? 0) == (qualificationVersion.Version ?? 0) &&
+                    otherVersion.LastUpdatedDate == qualificationVersion.LastUpdatedDate &&
+                    otherVersion.InsertedDate > qualificationVersion.InsertedDate
+                )
+            )));
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
@@ -1,10 +1,10 @@
+using SFA.DAS.AODP.Infrastructure.Models;
+
 namespace SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
 
 public interface IRolloverCandidateRepository
 {
     Task<int> CreateInitialRolloverCandidatesAsync(
-        string academicYear,
-        DateOnly academicYearEndDate,
-        DateTime createdAt,
+        AcademicYear academicYear,
         CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
@@ -6,5 +6,5 @@ public interface IRolloverCandidateRepository
         string academicYear,
         DateOnly academicYearEndDate,
         DateTime createdAt,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Interfaces/Rollover/IRolloverCandidateRepository.cs
@@ -1,0 +1,10 @@
+namespace SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+
+public interface IRolloverCandidateRepository
+{
+    Task<int> CreateInitialRolloverCandidatesAsync(
+        string academicYear,
+        DateOnly academicYearEndDate,
+        DateTime createdAt,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/AcademicYear.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/AcademicYear.cs
@@ -1,4 +1,4 @@
-namespace SFA.DAS.AODP.Jobs.Models.Rollover;
+namespace SFA.DAS.AODP.Infrastructure.Models;
 
 public sealed record AcademicYear(string Name, DateOnly StartDate, DateOnly EndDate)
 {
@@ -11,5 +11,14 @@ public sealed record AcademicYear(string Name, DateOnly StartDate, DateOnly EndD
             $"{startYear}/{endYear % 100:00}",
             new DateOnly(startYear, 8, 1),
             new DateOnly(endYear, 7, 31));
+    }
+
+    public static AcademicYear NextAcademicYear(AcademicYear academicYear)
+    {
+        var startDate = academicYear.StartDate.AddYears(1);
+        var endDate = academicYear.EndDate.AddYears(1);
+        var name = $"{startDate.Year}/{endDate.Year % 100:00}";
+
+        return new AcademicYear(name, startDate, endDate);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateFundingStream.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateFundingStream.cs
@@ -1,0 +1,10 @@
+namespace SFA.DAS.AODP.Infrastructure.Models.Rollover;
+
+public class RolloverCandidateFundingStream
+{
+    public Guid QualificationVersionId { get; init; }
+
+    public Guid FundingOfferId { get; init; }
+
+    public DateOnly? EndDate { get; init; }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateQueryBuilder.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateQueryBuilder.cs
@@ -1,0 +1,61 @@
+using SFA.DAS.AODP.Data.Entities;
+using SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
+
+namespace SFA.DAS.AODP.Infrastructure.Models.Rollover;
+
+public class RolloverCandidateQueryBuilder
+{
+    private readonly IQueryable<QualificationVersions> _allQualificationVersions;
+    private IQueryable<QualificationVersions> _qualificationVersions;
+    private IQueryable<QualificationFunding> _fundingStreams;
+
+    private RolloverCandidateQueryBuilder(
+        IQueryable<QualificationVersions> qualificationVersions,
+        IQueryable<QualificationFunding> fundingStreams)
+    {
+        _allQualificationVersions = qualificationVersions;
+        _qualificationVersions = qualificationVersions;
+        _fundingStreams = fundingStreams;
+    }
+
+    public static RolloverCandidateQueryBuilder From(
+        IQueryable<QualificationVersions> qualificationVersions,
+        IQueryable<QualificationFunding> fundingStreams)
+    {
+        return new RolloverCandidateQueryBuilder(qualificationVersions, fundingStreams);
+    }
+
+    public RolloverCandidateQueryBuilder WithLatestQualificationVersions()
+    {
+        _qualificationVersions = _qualificationVersions.WhereLatestVersionPerQualification(_allQualificationVersions);
+        return this;
+    }
+
+    public RolloverCandidateQueryBuilder WhereEligibleForFunding()
+    {
+        _qualificationVersions = _qualificationVersions.WhereEligibleForFunding();
+        return this;
+    }
+
+    public RolloverCandidateQueryBuilder WithActiveFundingStreamsForAcademicYear(DateOnly academicYearEndDate)
+    {
+        _fundingStreams = _fundingStreams.WhereActiveForAcademicYear(academicYearEndDate);
+        return this;
+    }
+
+    public IQueryable<RolloverCandidateFundingStream> Build()
+    {
+        return _fundingStreams
+            .Join(
+                _qualificationVersions,
+                funding => funding.QualificationVersionId,
+                qualificationVersion => qualificationVersion.Id,
+                (funding, qualificationVersion) => new RolloverCandidateFundingStream
+                {
+                    QualificationVersionId = qualificationVersion.Id,
+                    FundingOfferId = funding.FundingOfferId,
+                    EndDate = funding.EndDate
+                })
+            .Distinct();
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateQueryBuilder.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Models/Rollover/RolloverCandidateQueryBuilder.cs
@@ -37,9 +37,9 @@ public class RolloverCandidateQueryBuilder
         return this;
     }
 
-    public RolloverCandidateQueryBuilder WithActiveFundingStreamsForAcademicYear(DateOnly academicYearEndDate)
+    public RolloverCandidateQueryBuilder WithActiveFundingStreamsForAcademicYear(AcademicYear academicYear)
     {
-        _fundingStreams = _fundingStreams.WhereActiveForAcademicYear(academicYearEndDate);
+        _fundingStreams = _fundingStreams.WhereActiveForAcademicYear(academicYear);
         return this;
     }
 

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
@@ -2,16 +2,16 @@ using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Entities.Rollover;
 using SFA.DAS.AODP.Infrastructure.Context;
 using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models;
 using SFA.DAS.AODP.Infrastructure.Models.Rollover;
+using SFA.DAS.Funding.ApprenticeshipEarnings.Domain.Services;
 
 namespace SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
 
-public class RolloverCandidateRepository(IApplicationDbContext context) : IRolloverCandidateRepository
+public class RolloverCandidateRepository(IApplicationDbContext context, ISystemClockService systemClockService) : IRolloverCandidateRepository
 {
     public async Task<int> CreateInitialRolloverCandidatesAsync(
-        string academicYear,
-        DateOnly academicYearEndDate,
-        DateTime createdAt,
+        AcademicYear academicYear,
         CancellationToken cancellationToken)
     {
         var candidateFundingStreams = await RolloverCandidateQueryBuilder
@@ -20,7 +20,7 @@ public class RolloverCandidateRepository(IApplicationDbContext context) : IRollo
                 context.QualificationFundings.AsNoTracking())
             .WithLatestQualificationVersions()
             .WhereEligibleForFunding()
-            .WithActiveFundingStreamsForAcademicYear(academicYearEndDate)
+            .WithActiveFundingStreamsForAcademicYear(academicYear)
             .Build()
             .ToListAsync(cancellationToken);
 
@@ -42,7 +42,7 @@ public class RolloverCandidateRepository(IApplicationDbContext context) : IRollo
         var existingCandidateKeys = await context.RolloverCandidates
             .AsNoTracking()
             .Where(candidate =>
-                candidate.AcademicYear == academicYear &&
+                candidate.AcademicYear == academicYear.Name &&
                 candidate.RolloverRound == 1 &&
                 qualificationVersionIds.Contains(candidate.QualificationVersionId) &&
                 fundingOfferIds.Contains(candidate.FundingOfferId))
@@ -60,8 +60,8 @@ public class RolloverCandidateRepository(IApplicationDbContext context) : IRollo
             .Select(candidate => RolloverCandidate.CreateInitialRound(
                 candidate.QualificationVersionId,
                 candidate.FundingOfferId,
-                academicYear,
-                createdAt,
+                academicYear.Name,
+                systemClockService.UtcNow,
                 candidate.EndDate))
             .ToList();
 

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AODP.Data.Entities.Rollover;
+using SFA.DAS.AODP.Infrastructure.Context;
+using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models.Rollover;
+
+namespace SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
+
+public class RolloverCandidateRepository : IRolloverCandidateRepository
+{
+    private readonly IApplicationDbContext _context;
+
+    public RolloverCandidateRepository(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> CreateInitialRolloverCandidatesAsync(
+        string academicYear,
+        DateOnly academicYearEndDate,
+        DateTime createdAt,
+        CancellationToken cancellationToken = default)
+    {
+        var candidateFundingStreams = await RolloverCandidateQueryBuilder
+            .From(
+                _context.QualificationVersions.AsNoTracking(),
+                _context.QualificationFundings.AsNoTracking())
+            .WithLatestQualificationVersions()
+            .WhereEligibleForFunding()
+            .WithActiveFundingStreamsForAcademicYear(academicYearEndDate)
+            .Build()
+            .ToListAsync(cancellationToken);
+
+        if (candidateFundingStreams.Count == 0)
+        {
+            return 0;
+        }
+
+        var qualificationVersionIds = candidateFundingStreams
+            .Select(candidate => candidate.QualificationVersionId)
+            .Distinct()
+            .ToList();
+
+        var fundingOfferIds = candidateFundingStreams
+            .Select(candidate => candidate.FundingOfferId)
+            .Distinct()
+            .ToList();
+
+        var existingCandidateKeys = await _context.RolloverCandidates
+            .AsNoTracking()
+            .Where(candidate =>
+                candidate.AcademicYear == academicYear &&
+                candidate.RolloverRound == 1 &&
+                qualificationVersionIds.Contains(candidate.QualificationVersionId) &&
+                fundingOfferIds.Contains(candidate.FundingOfferId))
+            .Select(candidate => new
+            {
+                candidate.QualificationVersionId,
+                candidate.FundingOfferId
+            })
+            .ToListAsync(cancellationToken);
+
+        var newCandidates = candidateFundingStreams
+            .Where(candidate => !existingCandidateKeys.Any(existing =>
+                existing.QualificationVersionId == candidate.QualificationVersionId &&
+                existing.FundingOfferId == candidate.FundingOfferId))
+            .Select(candidate => RolloverCandidate.CreateInitialRound(
+                candidate.QualificationVersionId,
+                candidate.FundingOfferId,
+                academicYear,
+                createdAt,
+                candidate.EndDate))
+            .ToList();
+
+        if (newCandidates.Count == 0)
+        {
+            return 0;
+        }
+
+        _context.RolloverCandidates.AddRange(newCandidates);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return newCandidates.Count;
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
+++ b/src/SFA.DAS.AODP.Jobs.Infrastructure/Repositories/Rollover/RolloverCandidateRepository.cs
@@ -6,25 +6,18 @@ using SFA.DAS.AODP.Infrastructure.Models.Rollover;
 
 namespace SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
 
-public class RolloverCandidateRepository : IRolloverCandidateRepository
+public class RolloverCandidateRepository(IApplicationDbContext context) : IRolloverCandidateRepository
 {
-    private readonly IApplicationDbContext _context;
-
-    public RolloverCandidateRepository(IApplicationDbContext context)
-    {
-        _context = context;
-    }
-
     public async Task<int> CreateInitialRolloverCandidatesAsync(
         string academicYear,
         DateOnly academicYearEndDate,
         DateTime createdAt,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         var candidateFundingStreams = await RolloverCandidateQueryBuilder
             .From(
-                _context.QualificationVersions.AsNoTracking(),
-                _context.QualificationFundings.AsNoTracking())
+                context.QualificationVersions.AsNoTracking(),
+                context.QualificationFundings.AsNoTracking())
             .WithLatestQualificationVersions()
             .WhereEligibleForFunding()
             .WithActiveFundingStreamsForAcademicYear(academicYearEndDate)
@@ -46,7 +39,7 @@ public class RolloverCandidateRepository : IRolloverCandidateRepository
             .Distinct()
             .ToList();
 
-        var existingCandidateKeys = await _context.RolloverCandidates
+        var existingCandidateKeys = await context.RolloverCandidates
             .AsNoTracking()
             .Where(candidate =>
                 candidate.AcademicYear == academicYear &&
@@ -77,8 +70,8 @@ public class RolloverCandidateRepository : IRolloverCandidateRepository
             return 0;
         }
 
-        _context.RolloverCandidates.AddRange(newCandidates);
-        await _context.SaveChangesAsync(cancellationToken);
+        context.RolloverCandidates.AddRange(newCandidates);
+        await context.SaveChangesAsync(cancellationToken);
 
         return newCandidates.Count;
     }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/Rollover/RolloverCandidatesFunctionTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/Rollover/RolloverCandidatesFunctionTests.cs
@@ -1,6 +1,6 @@
+using SFA.DAS.AODP.Jobs.Functions.Abstractions;
 using SFA.DAS.AODP.Jobs.Functions.Rollover;
 using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
-using SFA.DAS.AODP.Jobs.Test.Mocks;
 
 namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Functions.Rollover;
 
@@ -12,25 +12,12 @@ public class RolloverCandidatesFunctionTests
         // Arrange
         var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
         var service = new Mock<IRolloverCandidateService>();
-        var jobConfigurationService = new Mock<IJobConfigurationService>();
-        var jobId = Guid.NewGuid();
-        var jobRunId = Guid.NewGuid();
+        var jobFunctionRunnerMock = new Mock<IJobFunctionRunner>();
+        
+        jobFunctionRunnerMock.Setup(x => x.RunAsync("RolloverCandidatesFunction", "SYSTEM", JobNames.RolloverCandidates, It.IsAny<Func<JobControl, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OkObjectResult(10));
 
-        jobConfigurationService
-            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
-            .ReturnsAsync(new JobControl
-            {
-                JobEnabled = true,
-                JobId = jobId,
-                Status = JobStatus.Completed.ToString()
-            });
-        jobConfigurationService
-            .Setup(x => x.InsertJobRunAsync(jobId, "SYSTEM", JobStatus.Running))
-            .ReturnsAsync(jobRunId);
-        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(5);
-
-        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobFunctionRunnerMock.Object);
 
         var timerInfo = new TimerInfo
         {
@@ -42,113 +29,35 @@ public class RolloverCandidatesFunctionTests
         var functionContext = new Mock<FunctionContext>().Object;
 
         // Act
-        await function.Run(timerInfo, functionContext);
+        var result = await function.Run(timerInfo, functionContext);
 
         // Assert
-        service.Verify(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
-        jobConfigurationService.Verify(x => x.UpdateJobRun("SYSTEM", jobId, jobRunId, 5, JobStatus.Completed), Times.Once);
+        result.ShouldBeOfType<OkObjectResult>();
+        jobFunctionRunnerMock.Verify(
+            x => x.RunAsync(
+                "RolloverCandidatesFunction",
+                "SYSTEM",
+                JobNames.RolloverCandidates,
+                It.IsAny<Func<JobControl, CancellationToken, Task<int>>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
-
-    [Fact]
-    public async Task RunManual_GeneratesRolloverCandidates()
-    {
-        // Arrange
-        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
-        var service = new Mock<IRolloverCandidateService>();
-        var jobConfigurationService = new Mock<IJobConfigurationService>();
-        var jobId = Guid.NewGuid();
-        var jobRunId = Guid.NewGuid();
-        var functionContext = new Mock<FunctionContext>().Object;
-
-        jobConfigurationService
-            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
-            .ReturnsAsync(new JobControl
-            {
-                JobEnabled = true,
-                JobId = jobId,
-                Status = JobStatus.Completed.ToString()
-            });
-        jobConfigurationService
-            .Setup(x => x.InsertJobRunAsync(jobId, "manual-user", JobStatus.Running))
-            .ReturnsAsync(jobRunId);
-        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(3);
-
-        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
-        var request = new MockHttpRequestData(functionContext);
-
-        // Act
-        var result = await function.RunManual(request, "manual-user");
-
-        // Assert
-        var okResult = result.ShouldBeOfType<OkObjectResult>();
-        okResult.Value.ShouldBe("[RolloverCandidatesFunction] -> 3 rollover candidates created.");
-        jobConfigurationService.Verify(x => x.UpdateJobRun("manual-user", jobId, jobRunId, 3, JobStatus.Completed), Times.Once);
-    }
-
-    [Fact]
-    public async Task RunManual_ReturnsSuccessfulNoOp_WhenNoCandidatesAreCreated()
-    {
-        // Arrange
-        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
-        var service = new Mock<IRolloverCandidateService>();
-        var jobConfigurationService = new Mock<IJobConfigurationService>();
-        var jobId = Guid.NewGuid();
-        var jobRunId = Guid.NewGuid();
-        var functionContext = new Mock<FunctionContext>().Object;
-
-        jobConfigurationService
-            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
-            .ReturnsAsync(new JobControl
-            {
-                JobEnabled = true,
-                JobId = jobId,
-                Status = JobStatus.Completed.ToString()
-            });
-        jobConfigurationService
-            .Setup(x => x.InsertJobRunAsync(jobId, "manual-user", JobStatus.Running))
-            .ReturnsAsync(jobRunId);
-        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0);
-
-        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
-        var request = new MockHttpRequestData(functionContext);
-
-        // Act
-        var result = await function.RunManual(request, "manual-user");
-
-        // Assert
-        var okResult = result.ShouldBeOfType<OkObjectResult>();
-        okResult.Value.ShouldBe("[RolloverCandidatesFunction] -> No qualification versions were added as rollover candidates.");
-        jobConfigurationService.Verify(x => x.UpdateJobRun("manual-user", jobId, jobRunId, 0, JobStatus.Completed), Times.Once);
-    }
-
+    
     [Fact]
     public async Task Run_RethrowsExceptionAndMarksJobRunAsError_WhenGenerationFails()
     {
         // Arrange
         var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
         var service = new Mock<IRolloverCandidateService>();
-        var jobConfigurationService = new Mock<IJobConfigurationService>();
-        var jobId = Guid.NewGuid();
-        var jobRunId = Guid.NewGuid();
         var expectedException = new InvalidOperationException("Generation failed");
 
-        jobConfigurationService
-            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
-            .ReturnsAsync(new JobControl
-            {
-                JobEnabled = true,
-                JobId = jobId,
-                Status = JobStatus.Completed.ToString()
-            });
-        jobConfigurationService
-            .Setup(x => x.InsertJobRunAsync(jobId, "SYSTEM", JobStatus.Running))
-            .ReturnsAsync(jobRunId);
-        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
+        var jobFunctionRunnerMock = new Mock<IJobFunctionRunner>();
+
+        jobFunctionRunnerMock.Setup(x => x.RunAsync("RolloverCandidatesFunction", "SYSTEM", JobNames.RolloverCandidates,
+                It.IsAny<Func<JobControl, CancellationToken, Task<int>>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(expectedException);
 
-        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobFunctionRunnerMock.Object);
 
         var timerInfo = new TimerInfo();
         var functionContext = new Mock<FunctionContext>().Object;
@@ -158,6 +67,13 @@ public class RolloverCandidatesFunctionTests
 
         // Assert
         exception.ShouldBe(expectedException);
-        jobConfigurationService.Verify(x => x.UpdateJobRun("SYSTEM", jobId, jobRunId, 0, JobStatus.Error), Times.Once);
+        jobFunctionRunnerMock.Verify(
+            x => x.RunAsync(
+                "RolloverCandidatesFunction",
+                "SYSTEM",
+                JobNames.RolloverCandidates,
+                It.IsAny<Func<JobControl, CancellationToken, Task<int>>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/Rollover/RolloverCandidatesFunctionTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Functions/Rollover/RolloverCandidatesFunctionTests.cs
@@ -1,0 +1,163 @@
+using SFA.DAS.AODP.Jobs.Functions.Rollover;
+using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.Test.Mocks;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Functions.Rollover;
+
+public class RolloverCandidatesFunctionTests
+{
+    [Fact]
+    public async Task Run_GeneratesRolloverCandidatesAndUpdatesJobRun()
+    {
+        // Arrange
+        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
+        var service = new Mock<IRolloverCandidateService>();
+        var jobConfigurationService = new Mock<IJobConfigurationService>();
+        var jobId = Guid.NewGuid();
+        var jobRunId = Guid.NewGuid();
+
+        jobConfigurationService
+            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
+            .ReturnsAsync(new JobControl
+            {
+                JobEnabled = true,
+                JobId = jobId,
+                Status = JobStatus.Completed.ToString()
+            });
+        jobConfigurationService
+            .Setup(x => x.InsertJobRunAsync(jobId, "SYSTEM", JobStatus.Running))
+            .ReturnsAsync(jobRunId);
+        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(5);
+
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+
+        var timerInfo = new TimerInfo
+        {
+            ScheduleStatus = new ScheduleStatus
+            {
+                Next = DateTime.UtcNow.AddYears(1)
+            }
+        };
+        var functionContext = new Mock<FunctionContext>().Object;
+
+        // Act
+        await function.Run(timerInfo, functionContext);
+
+        // Assert
+        service.Verify(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        jobConfigurationService.Verify(x => x.UpdateJobRun("SYSTEM", jobId, jobRunId, 5, JobStatus.Completed), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunManual_GeneratesRolloverCandidates()
+    {
+        // Arrange
+        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
+        var service = new Mock<IRolloverCandidateService>();
+        var jobConfigurationService = new Mock<IJobConfigurationService>();
+        var jobId = Guid.NewGuid();
+        var jobRunId = Guid.NewGuid();
+        var functionContext = new Mock<FunctionContext>().Object;
+
+        jobConfigurationService
+            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
+            .ReturnsAsync(new JobControl
+            {
+                JobEnabled = true,
+                JobId = jobId,
+                Status = JobStatus.Completed.ToString()
+            });
+        jobConfigurationService
+            .Setup(x => x.InsertJobRunAsync(jobId, "manual-user", JobStatus.Running))
+            .ReturnsAsync(jobRunId);
+        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+        var request = new MockHttpRequestData(functionContext);
+
+        // Act
+        var result = await function.RunManual(request, "manual-user");
+
+        // Assert
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.Value.ShouldBe("[RolloverCandidatesFunction] -> 3 rollover candidates created.");
+        jobConfigurationService.Verify(x => x.UpdateJobRun("manual-user", jobId, jobRunId, 3, JobStatus.Completed), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunManual_ReturnsSuccessfulNoOp_WhenNoCandidatesAreCreated()
+    {
+        // Arrange
+        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
+        var service = new Mock<IRolloverCandidateService>();
+        var jobConfigurationService = new Mock<IJobConfigurationService>();
+        var jobId = Guid.NewGuid();
+        var jobRunId = Guid.NewGuid();
+        var functionContext = new Mock<FunctionContext>().Object;
+
+        jobConfigurationService
+            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
+            .ReturnsAsync(new JobControl
+            {
+                JobEnabled = true,
+                JobId = jobId,
+                Status = JobStatus.Completed.ToString()
+            });
+        jobConfigurationService
+            .Setup(x => x.InsertJobRunAsync(jobId, "manual-user", JobStatus.Running))
+            .ReturnsAsync(jobRunId);
+        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+        var request = new MockHttpRequestData(functionContext);
+
+        // Act
+        var result = await function.RunManual(request, "manual-user");
+
+        // Assert
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.Value.ShouldBe("[RolloverCandidatesFunction] -> No qualification versions were added as rollover candidates.");
+        jobConfigurationService.Verify(x => x.UpdateJobRun("manual-user", jobId, jobRunId, 0, JobStatus.Completed), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_RethrowsExceptionAndMarksJobRunAsError_WhenGenerationFails()
+    {
+        // Arrange
+        var logger = new Mock<ILogger<RolloverCandidatesFunction>>();
+        var service = new Mock<IRolloverCandidateService>();
+        var jobConfigurationService = new Mock<IJobConfigurationService>();
+        var jobId = Guid.NewGuid();
+        var jobRunId = Guid.NewGuid();
+        var expectedException = new InvalidOperationException("Generation failed");
+
+        jobConfigurationService
+            .Setup(x => x.ReadJobConfiguration(JobNames.RolloverCandidates))
+            .ReturnsAsync(new JobControl
+            {
+                JobEnabled = true,
+                JobId = jobId,
+                Status = JobStatus.Completed.ToString()
+            });
+        jobConfigurationService
+            .Setup(x => x.InsertJobRunAsync(jobId, "SYSTEM", JobStatus.Running))
+            .ReturnsAsync(jobRunId);
+        service.Setup(x => x.GenerateRolloverCandidatesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(expectedException);
+
+        var function = new RolloverCandidatesFunction(logger.Object, service.Object, jobConfigurationService.Object);
+
+        var timerInfo = new TimerInfo();
+        var functionContext = new Mock<FunctionContext>().Object;
+
+        // Act
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => function.Run(timerInfo, functionContext));
+
+        // Assert
+        exception.ShouldBe(expectedException);
+        jobConfigurationService.Verify(x => x.UpdateJobRun("SYSTEM", jobId, jobRunId, 0, JobStatus.Error), Times.Once);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/AcademicYearTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/AcademicYearTests.cs
@@ -1,4 +1,4 @@
-using SFA.DAS.AODP.Jobs.Models.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models;
 
 namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
 

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/AcademicYearTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/AcademicYearTests.cs
@@ -1,0 +1,33 @@
+using SFA.DAS.AODP.Jobs.Models.Rollover;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
+
+public class AcademicYearTests
+{
+    [Theory]
+    [InlineData(2026, 6, 28, "2025/26", 2025, 8, 1, 2026, 7, 31)]
+    [InlineData(2026, 8, 1, "2026/27", 2026, 8, 1, 2027, 7, 31)]
+    public void FromDate_ReturnsAcademicYearForDate(
+        int year,
+        int month,
+        int day,
+        string expectedName,
+        int expectedStartYear,
+        int expectedStartMonth,
+        int expectedStartDay,
+        int expectedEndYear,
+        int expectedEndMonth,
+        int expectedEndDay)
+    {
+        // Arrange
+        var date = new DateTime(year, month, day);
+
+        // Act
+        var result = AcademicYear.FromDate(date);
+
+        // Assert
+        result.Name.ShouldBe(expectedName);
+        result.StartDate.ShouldBe(new DateOnly(expectedStartYear, expectedStartMonth, expectedStartDay));
+        result.EndDate.ShouldBe(new DateOnly(expectedEndYear, expectedEndMonth, expectedEndDay));
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateQueryExtensionTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateQueryExtensionTests.cs
@@ -1,10 +1,11 @@
 using SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models;
 
 namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
 
 public class RolloverCandidateQueryExtensionTests
 {
-    private readonly DateOnly _academicYearEndDate = new(2026, 7, 31);
+    private readonly AcademicYear _academicYear = new("25/26", new DateOnly(2025, 08, 01), new DateOnly(2026, 7, 31));
 
     [Fact]
     public void WhereEligibleForFunding_ReturnsOnlyEligibleQualificationVersions()
@@ -32,8 +33,8 @@ public class RolloverCandidateQueryExtensionTests
     {
         // Arrange
         var openEndedFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, null, null);
-        var academicYearEndFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYearEndDate, null);
-        var expiredFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYearEndDate.AddDays(-1), null);
+        var academicYearEndFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYear.EndDate, null);
+        var expiredFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYear.StartDate.AddDays(-1), null);
         var query = new[]
         {
             openEndedFunding,
@@ -42,7 +43,7 @@ public class RolloverCandidateQueryExtensionTests
         }.AsQueryable();
 
         // Act
-        var result = query.WhereActiveForAcademicYear(_academicYearEndDate).ToList();
+        var result = query.WhereActiveForAcademicYear(_academicYear).ToList();
 
         // Assert
         result.ShouldBe([openEndedFunding, academicYearEndFunding]);

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateQueryExtensionTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateQueryExtensionTests.cs
@@ -1,0 +1,83 @@
+using SFA.DAS.AODP.Infrastructure.Extensions.Rollover;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
+
+public class RolloverCandidateQueryExtensionTests
+{
+    private readonly DateOnly _academicYearEndDate = new(2026, 7, 31);
+
+    [Fact]
+    public void WhereEligibleForFunding_ReturnsOnlyEligibleQualificationVersions()
+    {
+        // Arrange
+        var eligibleQualificationVersion = new QualificationVersions { Id = Guid.NewGuid(), EligibleForFunding = true };
+        var notEligibleQualificationVersion = new QualificationVersions { Id = Guid.NewGuid(), EligibleForFunding = false };
+        var nullEligibilityQualificationVersion = new QualificationVersions { Id = Guid.NewGuid(), EligibleForFunding = null };
+        var query = new[]
+        {
+            eligibleQualificationVersion,
+            notEligibleQualificationVersion,
+            nullEligibilityQualificationVersion
+        }.AsQueryable();
+
+        // Act
+        var result = query.WhereEligibleForFunding().ToList();
+
+        // Assert
+        result.ShouldBe([eligibleQualificationVersion]);
+    }
+
+    [Fact]
+    public void WhereActiveForAcademicYear_ReturnsOpenEndedAndAcademicYearEndFundingStreams()
+    {
+        // Arrange
+        var openEndedFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, null, null);
+        var academicYearEndFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYearEndDate, null);
+        var expiredFunding = QualificationFunding.Create(Guid.NewGuid(), Guid.NewGuid(), null, _academicYearEndDate.AddDays(-1), null);
+        var query = new[]
+        {
+            openEndedFunding,
+            academicYearEndFunding,
+            expiredFunding
+        }.AsQueryable();
+
+        // Act
+        var result = query.WhereActiveForAcademicYear(_academicYearEndDate).ToList();
+
+        // Assert
+        result.ShouldBe([openEndedFunding, academicYearEndFunding]);
+    }
+
+    [Fact]
+    public void WhereLatestVersionPerQualification_ReturnsLatestVersionForEachQualification()
+    {
+        // Arrange
+        var qualificationId = Guid.NewGuid();
+        var olderVersion = CreateQualificationVersion(Guid.NewGuid(), qualificationId, 1, new DateTime(2026, 1, 1), new DateTime(2026, 1, 1));
+        var latestVersion = CreateQualificationVersion(Guid.NewGuid(), qualificationId, 2, new DateTime(2026, 1, 1), new DateTime(2026, 1, 1));
+        var query = new[] { olderVersion, latestVersion }.AsQueryable();
+
+        // Act
+        var result = query.WhereLatestVersionPerQualification(query).ToList();
+
+        // Assert
+        result.ShouldBe([latestVersion]);
+    }
+
+    private static QualificationVersions CreateQualificationVersion(
+        Guid id,
+        Guid qualificationId,
+        int version,
+        DateTime lastUpdatedDate,
+        DateTime insertedDate)
+    {
+        return new QualificationVersions
+        {
+            Id = id,
+            QualificationId = qualificationId,
+            Version = version,
+            LastUpdatedDate = lastUpdatedDate,
+            InsertedDate = insertedDate
+        };
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateRepositoryTests.cs
@@ -1,18 +1,24 @@
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Entities.Rollover;
 using SFA.DAS.AODP.Infrastructure.Context;
+using SFA.DAS.AODP.Infrastructure.Models;
 using SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
 
 namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
 
 public class RolloverCandidateRepositoryTests
 {
+    private class FakeSystemClockService : ISystemClockService
+    {
+        public DateTime UtcNow => new(2026, 07, 01);
+    }
+
     [Fact]
     public async Task CreateInitialRolloverCandidatesAsync_CreatesCandidatesForLatestEligibleVersionsWithActiveFunding()
     {
         // Arrange
         await using var context = CreateContext();
-        var repository = new RolloverCandidateRepository(context);
+        var repository = new RolloverCandidateRepository(context, new FakeSystemClockService());
         var qualificationId = Guid.NewGuid();
         var olderVersionId = Guid.NewGuid();
         var latestVersionId = Guid.NewGuid();
@@ -20,7 +26,7 @@ public class RolloverCandidateRepositoryTests
         var activeOfferId = Guid.NewGuid();
         var openEndedOfferId = Guid.NewGuid();
         var expiredOfferId = Guid.NewGuid();
-        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+        var academicYear = new AcademicYear("2025/26", new DateOnly(2025, 8, 1), new DateOnly(2026, 7, 31));
 
         context.QualificationVersions.AddRange(
             CreateQualificationVersion(olderVersionId, qualificationId, 1, true),
@@ -31,15 +37,13 @@ public class RolloverCandidateRepositoryTests
             QualificationFunding.Create(olderVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null),
             QualificationFunding.Create(latestVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null),
             QualificationFunding.Create(latestVersionId, openEndedOfferId, null, null, null),
-            QualificationFunding.Create(latestVersionId, expiredOfferId, null, new DateOnly(2026, 7, 30), null),
+            QualificationFunding.Create(latestVersionId, expiredOfferId, null, new DateOnly(2025, 7, 30), null),
             QualificationFunding.Create(ineligibleVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null));
         await context.SaveChangesAsync();
 
         // Act
         var result = await repository.CreateInitialRolloverCandidatesAsync(
-            "2025/26",
-            new DateOnly(2026, 7, 31),
-            createdAt,
+            academicYear,
             CancellationToken.None);
 
         // Assert
@@ -58,10 +62,11 @@ public class RolloverCandidateRepositoryTests
     {
         // Arrange
         await using var context = CreateContext();
-        var repository = new RolloverCandidateRepository(context);
+        var repository = new RolloverCandidateRepository(context, new FakeSystemClockService());
         var qualificationVersionId = Guid.NewGuid();
         var fundingOfferId = Guid.NewGuid();
         var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+        var academicYear = new AcademicYear("2025/26", new DateOnly(2025, 8, 1), new DateOnly(2026, 7, 31));
 
         context.QualificationVersions.Add(CreateQualificationVersion(qualificationVersionId, Guid.NewGuid(), 1, true));
         context.QualificationFundings.Add(QualificationFunding.Create(qualificationVersionId, fundingOfferId, null, null, null));
@@ -70,9 +75,7 @@ public class RolloverCandidateRepositoryTests
 
         // Act
         var result = await repository.CreateInitialRolloverCandidatesAsync(
-            "2025/26",
-            new DateOnly(2026, 7, 31),
-            createdAt,
+            academicYear,
             CancellationToken.None);
 
         // Assert
@@ -85,26 +88,22 @@ public class RolloverCandidateRepositoryTests
     {
         // Arrange
         await using var context = CreateContext();
-        var repository = new RolloverCandidateRepository(context);
+        var repository = new RolloverCandidateRepository(context, new FakeSystemClockService());
         var qualificationVersionId = Guid.NewGuid();
         var fundingOfferId = Guid.NewGuid();
-        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+        var academicYear = new AcademicYear("2025/26", new DateOnly(2025, 8, 1), new DateOnly(2026, 7, 31));
 
         context.QualificationVersions.Add(CreateQualificationVersion(qualificationVersionId, Guid.NewGuid(), 1, true));
         context.QualificationFundings.Add(QualificationFunding.Create(qualificationVersionId, fundingOfferId, null, null, null));
         await context.SaveChangesAsync();
 
         await repository.CreateInitialRolloverCandidatesAsync(
-            "2025/26",
-            new DateOnly(2026, 7, 31),
-            createdAt,
+            academicYear,
             CancellationToken.None);
 
         // Act
         var result = await repository.CreateInitialRolloverCandidatesAsync(
-            "2025/26",
-            new DateOnly(2026, 7, 31),
-            createdAt,
+            academicYear,
             CancellationToken.None);
 
         // Assert
@@ -117,12 +116,12 @@ public class RolloverCandidateRepositoryTests
     {
         // Arrange
         await using var context = CreateContext();
-        var repository = new RolloverCandidateRepository(context);
+        var repository = new RolloverCandidateRepository(context, new FakeSystemClockService());
         var qualificationId = Guid.NewGuid();
         var olderEligibleVersionId = Guid.NewGuid();
         var latestIneligibleVersionId = Guid.NewGuid();
         var fundingOfferId = Guid.NewGuid();
-        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+        var academicYear = new AcademicYear("2025/26", new DateOnly(2025, 8, 1), new DateOnly(2026, 7, 31));
 
         context.QualificationVersions.AddRange(
             CreateQualificationVersion(olderEligibleVersionId, qualificationId, 1, true),
@@ -132,9 +131,7 @@ public class RolloverCandidateRepositoryTests
 
         // Act
         var result = await repository.CreateInitialRolloverCandidatesAsync(
-            "2025/26",
-            new DateOnly(2026, 7, 31),
-            createdAt,
+            academicYear,
             CancellationToken.None);
 
         // Assert

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateRepositoryTests.cs
@@ -1,0 +1,179 @@
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.AODP.Data.Entities.Rollover;
+using SFA.DAS.AODP.Infrastructure.Context;
+using SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
+
+public class RolloverCandidateRepositoryTests
+{
+    [Fact]
+    public async Task CreateInitialRolloverCandidatesAsync_CreatesCandidatesForLatestEligibleVersionsWithActiveFunding()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var repository = new RolloverCandidateRepository(context);
+        var qualificationId = Guid.NewGuid();
+        var olderVersionId = Guid.NewGuid();
+        var latestVersionId = Guid.NewGuid();
+        var ineligibleVersionId = Guid.NewGuid();
+        var activeOfferId = Guid.NewGuid();
+        var openEndedOfferId = Guid.NewGuid();
+        var expiredOfferId = Guid.NewGuid();
+        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+
+        context.QualificationVersions.AddRange(
+            CreateQualificationVersion(olderVersionId, qualificationId, 1, true),
+            CreateQualificationVersion(latestVersionId, qualificationId, 2, true),
+            CreateQualificationVersion(ineligibleVersionId, Guid.NewGuid(), 1, false));
+
+        context.QualificationFundings.AddRange(
+            QualificationFunding.Create(olderVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null),
+            QualificationFunding.Create(latestVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null),
+            QualificationFunding.Create(latestVersionId, openEndedOfferId, null, null, null),
+            QualificationFunding.Create(latestVersionId, expiredOfferId, null, new DateOnly(2026, 7, 30), null),
+            QualificationFunding.Create(ineligibleVersionId, activeOfferId, null, new DateOnly(2026, 7, 31), null));
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await repository.CreateInitialRolloverCandidatesAsync(
+            "2025/26",
+            new DateOnly(2026, 7, 31),
+            createdAt,
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(2);
+        var stored = await context.RolloverCandidates.ToListAsync();
+        stored.Count.ShouldBe(2);
+        stored.ShouldAllBe(candidate => candidate.QualificationVersionId == latestVersionId);
+        stored.Select(candidate => candidate.FundingOfferId).ShouldBe([activeOfferId, openEndedOfferId], ignoreOrder: true);
+        stored.ShouldAllBe(candidate => candidate.AcademicYear == "2025/26");
+        stored.ShouldAllBe(candidate => candidate.RolloverRound == 1);
+        stored.ShouldAllBe(candidate => candidate.IsActive);
+    }
+
+    [Fact]
+    public async Task CreateInitialRolloverCandidatesAsync_DoesNotCreateDuplicateCandidates()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var repository = new RolloverCandidateRepository(context);
+        var qualificationVersionId = Guid.NewGuid();
+        var fundingOfferId = Guid.NewGuid();
+        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+
+        context.QualificationVersions.Add(CreateQualificationVersion(qualificationVersionId, Guid.NewGuid(), 1, true));
+        context.QualificationFundings.Add(QualificationFunding.Create(qualificationVersionId, fundingOfferId, null, null, null));
+        context.RolloverCandidates.Add(RolloverCandidate.CreateInitialRound(qualificationVersionId, fundingOfferId, "2025/26", createdAt, null));
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await repository.CreateInitialRolloverCandidatesAsync(
+            "2025/26",
+            new DateOnly(2026, 7, 31),
+            createdAt,
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(0);
+        context.RolloverCandidates.Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CreateInitialRolloverCandidatesAsync_ReturnsZeroAndDoesNotDuplicate_WhenRunAgainForSameAcademicYear()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var repository = new RolloverCandidateRepository(context);
+        var qualificationVersionId = Guid.NewGuid();
+        var fundingOfferId = Guid.NewGuid();
+        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+
+        context.QualificationVersions.Add(CreateQualificationVersion(qualificationVersionId, Guid.NewGuid(), 1, true));
+        context.QualificationFundings.Add(QualificationFunding.Create(qualificationVersionId, fundingOfferId, null, null, null));
+        await context.SaveChangesAsync();
+
+        await repository.CreateInitialRolloverCandidatesAsync(
+            "2025/26",
+            new DateOnly(2026, 7, 31),
+            createdAt,
+            CancellationToken.None);
+
+        // Act
+        var result = await repository.CreateInitialRolloverCandidatesAsync(
+            "2025/26",
+            new DateOnly(2026, 7, 31),
+            createdAt,
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(0);
+        context.RolloverCandidates.Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CreateInitialRolloverCandidatesAsync_DoesNotCreateCandidate_WhenLatestVersionIsNotEligible()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var repository = new RolloverCandidateRepository(context);
+        var qualificationId = Guid.NewGuid();
+        var olderEligibleVersionId = Guid.NewGuid();
+        var latestIneligibleVersionId = Guid.NewGuid();
+        var fundingOfferId = Guid.NewGuid();
+        var createdAt = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+
+        context.QualificationVersions.AddRange(
+            CreateQualificationVersion(olderEligibleVersionId, qualificationId, 1, true),
+            CreateQualificationVersion(latestIneligibleVersionId, qualificationId, 2, false));
+        context.QualificationFundings.Add(QualificationFunding.Create(olderEligibleVersionId, fundingOfferId, null, null, null));
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await repository.CreateInitialRolloverCandidatesAsync(
+            "2025/26",
+            new DateOnly(2026, 7, 31),
+            createdAt,
+            CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(0);
+        context.RolloverCandidates.ShouldBeEmpty();
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static QualificationVersions CreateQualificationVersion(Guid id, Guid qualificationId, int version, bool eligibleForFunding)
+    {
+        return new QualificationVersions
+        {
+            Id = id,
+            QualificationId = qualificationId,
+            Version = version,
+            EligibleForFunding = eligibleForFunding,
+            VersionFieldChangesId = Guid.NewGuid(),
+            ProcessStatusId = Guid.NewGuid(),
+            LifecycleStageId = Guid.NewGuid(),
+            AwardingOrganisationId = Guid.NewGuid(),
+            Status = "Approved",
+            Type = "Type",
+            Ssa = "SSA",
+            Level = "Level 3",
+            SubLevel = string.Empty,
+            EqfLevel = string.Empty,
+            RegulationStartDate = DateTime.UtcNow,
+            OperationalStartDate = DateTime.UtcNow,
+            LastUpdatedDate = DateTime.UtcNow,
+            UiLastUpdatedDate = DateTime.UtcNow,
+            InsertedDate = DateTime.UtcNow
+        };
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
@@ -14,7 +14,7 @@ public class RolloverCandidateServiceTests
         var clock = new Mock<ISystemClockService>();
         var now = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
         clock.Setup(x => x.UtcNow).Returns(now);
-        var academicYear = new AcademicYear("2026/27", new DateOnly(2026, 8, 1), new DateOnly(2027, 7, 31));
+        var academicYear = new AcademicYear("2025/26", new DateOnly(2025, 8, 1), new DateOnly(2026, 7, 31));
 
         repository
             .Setup(x => x.CreateInitialRolloverCandidatesAsync(academicYear, It.IsAny<CancellationToken>()))

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
@@ -1,0 +1,29 @@
+using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.Services.Rollover;
+
+namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
+
+public class RolloverCandidateServiceTests
+{
+    [Fact]
+    public async Task GenerateRolloverCandidatesAsync_UsesCurrentAcademicYear()
+    {
+        // Arrange
+        var repository = new Mock<IRolloverCandidateRepository>();
+        var clock = new Mock<ISystemClockService>();
+        var now = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
+        clock.Setup(x => x.UtcNow).Returns(now);
+        repository
+            .Setup(x => x.CreateInitialRolloverCandidatesAsync("2025/26", new DateOnly(2026, 7, 31), now, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7);
+
+        var service = new RolloverCandidateService(repository.Object, clock.Object);
+
+        // Act
+        var result = await service.GenerateRolloverCandidatesAsync(CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(7);
+        repository.Verify(x => x.CreateInitialRolloverCandidatesAsync("2025/26", new DateOnly(2026, 7, 31), now, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/Application/Services/Rollover/RolloverCandidateServiceTests.cs
@@ -1,4 +1,5 @@
 using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models;
 using SFA.DAS.AODP.Jobs.Services.Rollover;
 
 namespace SFA.DAS.AODP.Jobs.UnitTests.Application.Services.Rollover;
@@ -13,8 +14,10 @@ public class RolloverCandidateServiceTests
         var clock = new Mock<ISystemClockService>();
         var now = new DateTime(2026, 6, 28, 9, 30, 0, DateTimeKind.Utc);
         clock.Setup(x => x.UtcNow).Returns(now);
+        var academicYear = new AcademicYear("2026/27", new DateOnly(2026, 8, 1), new DateOnly(2027, 7, 31));
+
         repository
-            .Setup(x => x.CreateInitialRolloverCandidatesAsync("2025/26", new DateOnly(2026, 7, 31), now, It.IsAny<CancellationToken>()))
+            .Setup(x => x.CreateInitialRolloverCandidatesAsync(academicYear, It.IsAny<CancellationToken>()))
             .ReturnsAsync(7);
 
         var service = new RolloverCandidateService(repository.Object, clock.Object);
@@ -24,6 +27,6 @@ public class RolloverCandidateServiceTests
 
         // Assert
         result.ShouldBe(7);
-        repository.Verify(x => x.CreateInitialRolloverCandidatesAsync("2025/26", new DateOnly(2026, 7, 31), now, It.IsAny<CancellationToken>()), Times.Once);
+        repository.Verify(x => x.CreateInitialRolloverCandidatesAsync(academicYear, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs.Test/GlobalUsings.cs
+++ b/src/SFA.DAS.AODP.Jobs.Test/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using Microsoft.Extensions.Logging;
 global using Moq;
 
 global using RestEase;
+global using Shouldly;
 
 global using SFA.DAS.AODP.Common.Enum;
 global using SFA.DAS.AODP.Data.Entities;

--- a/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
+++ b/src/SFA.DAS.AODP.Jobs.Test/SFA.DAS.AODP.Jobs.UnitTests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
@@ -1,132 +1,31 @@
-using Microsoft.Azure.Functions.Worker.Http;
+using SFA.DAS.AODP.Jobs.Functions.Abstractions;
 using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
-using SFA.DAS.AODP.Jobs.LoggerMessages;
 
 namespace SFA.DAS.AODP.Jobs.Functions.Rollover;
 
-public class RolloverCandidatesFunction
+public class RolloverCandidatesFunction(
+    ILogger<RolloverCandidatesFunction> logger,
+    IRolloverCandidateService rolloverCandidateService,
+    IJobFunctionRunner jobFunctionRunner)
 {
-    private readonly ILogger<RolloverCandidatesFunction> _logger;
-    private readonly IRolloverCandidateService _rolloverCandidateService;
-    private readonly IJobConfigurationService _jobConfigurationService;
+    private readonly ILogger<RolloverCandidatesFunction> _logger = logger;
+    private readonly IRolloverCandidateService _rolloverCandidateService = rolloverCandidateService;
+    private readonly IJobFunctionRunner _jobFunctionRunner = jobFunctionRunner;
 
     private const string FunctionName = nameof(RolloverCandidatesFunction);
     private const string SystemUser = "SYSTEM";
 
-    public RolloverCandidatesFunction(
-        ILogger<RolloverCandidatesFunction> logger,
-        IRolloverCandidateService rolloverCandidateService,
-        IJobConfigurationService jobConfigurationService)
-    {
-        _logger = logger;
-        _rolloverCandidateService = rolloverCandidateService;
-        _jobConfigurationService = jobConfigurationService;
-    }
-
     [Function("RolloverCandidatesFunction")]
-    public async Task Run([TimerTrigger("%RolloverCandidatesTimerSchedule%")] TimerInfo timerInfo, FunctionContext functionContext)
+    public async Task<IActionResult> Run([TimerTrigger("%RolloverCandidatesTimerSchedule%")] TimerInfo timerInfo, FunctionContext functionContext)
     {
-        if (timerInfo.ScheduleStatus is not null)
-        {
-            _logger.NextTimerSchedule(FunctionName, timerInfo.ScheduleStatus.Next);
-        }
-
-        await ExecuteAsync(SystemUser, functionContext.CancellationToken);
+        return await _jobFunctionRunner.RunAsync(
+            FunctionName, 
+            SystemUser, 
+            JobNames.RolloverCandidates,
+            DoWorkAsync, 
+            functionContext.CancellationToken);
     }
 
-    [Function("RolloverCandidatesManualFunction")]
-    public async Task<IActionResult> RunManual(
-        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = "api/rolloverCandidates/{username?}")]
-        HttpRequestData request,
-        string username = "")
-    {
-        var result = await ExecuteAsync(
-            string.IsNullOrWhiteSpace(username) ? SystemUser : username,
-            request.FunctionContext.CancellationToken);
-
-        return new OkObjectResult($"[{FunctionName}] -> {result.Message}");
-    }
-
-    private async Task<RolloverCandidatesExecutionResult> ExecuteAsync(string username, CancellationToken cancellationToken)
-    {
-        var jobControl = new JobControl();
-
-        try
-        {
-            _logger.GenerationStarted(FunctionName);
-
-            jobControl = await _jobConfigurationService.ReadJobConfiguration(JobNames.RolloverCandidates);
-
-            if (!jobControl.JobEnabled)
-            {
-                FunctionLoggerMessages.JobDisabled(_logger, FunctionName);
-                return RolloverCandidatesExecutionResult.Skipped("Job disabled");
-            }
-
-            if (jobControl.Status == JobStatus.Running.ToString())
-            {
-                FunctionLoggerMessages.JobRunning(_logger, FunctionName);
-                return RolloverCandidatesExecutionResult.Skipped("Job currently running");
-            }
-
-            jobControl.JobRunId = await _jobConfigurationService.InsertJobRunAsync(
-                jobControl.JobId,
-                username,
-                JobStatus.Running);
-
-            var candidatesCreated = await _rolloverCandidateService.GenerateRolloverCandidatesAsync(cancellationToken);
-
-            await _jobConfigurationService.UpdateJobRun(
-                username,
-                jobControl.JobId,
-                jobControl.JobRunId,
-                candidatesCreated,
-                JobStatus.Completed);
-
-            if (candidatesCreated == 0)
-            {
-                _logger.NoCandidatesCreated(FunctionName);
-                return RolloverCandidatesExecutionResult.NoCandidatesCreated();
-            }
-
-            _logger.CandidatesCreated(FunctionName, candidatesCreated);
-
-            return RolloverCandidatesExecutionResult.Completed(candidatesCreated);
-        }
-        catch (Exception ex)
-        {
-            _logger.GenerationFailed(ex, FunctionName);
-
-            try
-            {
-                if (jobControl.JobId != Guid.Empty)
-                {
-                    await _jobConfigurationService.UpdateJobRun(
-                        username,
-                        jobControl.JobId,
-                        jobControl.JobRunId,
-                        0,
-                        JobStatus.Error);
-                }
-            }
-            catch (Exception updateException)
-            {
-                _logger.FailedToMarkJobRunAsErrored(updateException, FunctionName);
-            }
-
-            throw;
-        }
-    }
-
-    private sealed record RolloverCandidatesExecutionResult(string Message)
-    {
-        public static RolloverCandidatesExecutionResult Completed(int candidatesCreated) =>
-            new($"{candidatesCreated} rollover candidates created.");
-
-        public static RolloverCandidatesExecutionResult NoCandidatesCreated() =>
-            new("No qualification versions were added as rollover candidates.");
-
-        public static RolloverCandidatesExecutionResult Skipped(string reason) =>
-            new(reason);
-    }
+    private async Task<int> DoWorkAsync(JobControl control, CancellationToken cancellationToken) 
+        => await _rolloverCandidateService.GenerateRolloverCandidatesAsync(cancellationToken);
 }

--- a/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
@@ -1,0 +1,132 @@
+using Microsoft.Azure.Functions.Worker.Http;
+using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.LoggerMessages;
+
+namespace SFA.DAS.AODP.Jobs.Functions.Rollover;
+
+public class RolloverCandidatesFunction
+{
+    private readonly ILogger<RolloverCandidatesFunction> _logger;
+    private readonly IRolloverCandidateService _rolloverCandidateService;
+    private readonly IJobConfigurationService _jobConfigurationService;
+
+    private const string FunctionName = nameof(RolloverCandidatesFunction);
+    private const string SystemUser = "SYSTEM";
+
+    public RolloverCandidatesFunction(
+        ILogger<RolloverCandidatesFunction> logger,
+        IRolloverCandidateService rolloverCandidateService,
+        IJobConfigurationService jobConfigurationService)
+    {
+        _logger = logger;
+        _rolloverCandidateService = rolloverCandidateService;
+        _jobConfigurationService = jobConfigurationService;
+    }
+
+    [Function("RolloverCandidatesFunction")]
+    public async Task Run([TimerTrigger("%RolloverCandidatesTimerSchedule%")] TimerInfo timerInfo, FunctionContext functionContext)
+    {
+        if (timerInfo.ScheduleStatus is not null)
+        {
+            _logger.NextTimerSchedule(FunctionName, timerInfo.ScheduleStatus.Next);
+        }
+
+        await ExecuteAsync(SystemUser, functionContext.CancellationToken);
+    }
+
+    [Function("RolloverCandidatesManualFunction")]
+    public async Task<IActionResult> RunManual(
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = "api/rolloverCandidates/{username?}")]
+        HttpRequestData request,
+        string username = "")
+    {
+        var result = await ExecuteAsync(
+            string.IsNullOrWhiteSpace(username) ? SystemUser : username,
+            request.FunctionContext.CancellationToken);
+
+        return new OkObjectResult($"[{FunctionName}] -> {result.Message}");
+    }
+
+    private async Task<RolloverCandidatesExecutionResult> ExecuteAsync(string username, CancellationToken cancellationToken)
+    {
+        var jobControl = new JobControl();
+
+        try
+        {
+            _logger.GenerationStarted(FunctionName);
+
+            jobControl = await _jobConfigurationService.ReadJobConfiguration(JobNames.RolloverCandidates);
+
+            if (!jobControl.JobEnabled)
+            {
+                FunctionLoggerMessages.JobDisabled(_logger, FunctionName);
+                return RolloverCandidatesExecutionResult.Skipped("Job disabled");
+            }
+
+            if (jobControl.Status == JobStatus.Running.ToString())
+            {
+                FunctionLoggerMessages.JobRunning(_logger, FunctionName);
+                return RolloverCandidatesExecutionResult.Skipped("Job currently running");
+            }
+
+            jobControl.JobRunId = await _jobConfigurationService.InsertJobRunAsync(
+                jobControl.JobId,
+                username,
+                JobStatus.Running);
+
+            var candidatesCreated = await _rolloverCandidateService.GenerateRolloverCandidatesAsync(cancellationToken);
+
+            await _jobConfigurationService.UpdateJobRun(
+                username,
+                jobControl.JobId,
+                jobControl.JobRunId,
+                candidatesCreated,
+                JobStatus.Completed);
+
+            if (candidatesCreated == 0)
+            {
+                _logger.NoCandidatesCreated(FunctionName);
+                return RolloverCandidatesExecutionResult.NoCandidatesCreated();
+            }
+
+            _logger.CandidatesCreated(FunctionName, candidatesCreated);
+
+            return RolloverCandidatesExecutionResult.Completed(candidatesCreated);
+        }
+        catch (Exception ex)
+        {
+            _logger.GenerationFailed(ex, FunctionName);
+
+            try
+            {
+                if (jobControl.JobId != Guid.Empty)
+                {
+                    await _jobConfigurationService.UpdateJobRun(
+                        username,
+                        jobControl.JobId,
+                        jobControl.JobRunId,
+                        0,
+                        JobStatus.Error);
+                }
+            }
+            catch (Exception updateException)
+            {
+                _logger.FailedToMarkJobRunAsErrored(updateException, FunctionName);
+            }
+
+            throw;
+        }
+    }
+
+    private sealed record RolloverCandidatesExecutionResult(string Message)
+    {
+        public static RolloverCandidatesExecutionResult Completed(int candidatesCreated) =>
+            new($"{candidatesCreated} rollover candidates created.");
+
+        public static RolloverCandidatesExecutionResult NoCandidatesCreated() =>
+            new("No qualification versions were added as rollover candidates.");
+
+        public static RolloverCandidatesExecutionResult Skipped(string reason) =>
+            new(reason);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
+++ b/src/SFA.DAS.AODP.Jobs/Functions/Rollover/RolloverCandidatesFunction.cs
@@ -16,7 +16,7 @@ public class RolloverCandidatesFunction(
     private const string SystemUser = "SYSTEM";
 
     [Function("RolloverCandidatesFunction")]
-    public async Task<IActionResult> Run([TimerTrigger("%RolloverCandidatesTimerSchedule%")] TimerInfo timerInfo, FunctionContext functionContext)
+    public async Task<IActionResult> Run([TimerTrigger("0 0 2 1 8 *")] TimerInfo timerInfo, FunctionContext functionContext)
     {
         return await _jobFunctionRunner.RunAsync(
             FunctionName, 

--- a/src/SFA.DAS.AODP.Jobs/Interfaces/Rollover/IRolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Interfaces/Rollover/IRolloverCandidateService.cs
@@ -2,5 +2,5 @@ namespace SFA.DAS.AODP.Jobs.Interfaces.Rollover;
 
 public interface IRolloverCandidateService
 {
-    Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken = default);
+    Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.AODP.Jobs/Interfaces/Rollover/IRolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Interfaces/Rollover/IRolloverCandidateService.cs
@@ -1,0 +1,6 @@
+namespace SFA.DAS.AODP.Jobs.Interfaces.Rollover;
+
+public interface IRolloverCandidateService
+{
+    Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/SFA.DAS.AODP.Jobs/LoggerMessages/RolloverCandidatesLoggerMessages.cs
+++ b/src/SFA.DAS.AODP.Jobs/LoggerMessages/RolloverCandidatesLoggerMessages.cs
@@ -1,0 +1,22 @@
+namespace SFA.DAS.AODP.Jobs.LoggerMessages;
+
+public static partial class RolloverCandidatesLoggerMessages
+{
+    [LoggerMessage(LogLevel.Information, message: "[{FunctionName}] -> Rollover candidate generation started.")]
+    public static partial void GenerationStarted(this ILogger logger, string functionName);
+
+    [LoggerMessage(LogLevel.Information, message: "[{FunctionName}] -> Next timer schedule at: {NextSchedule}")]
+    public static partial void NextTimerSchedule(this ILogger logger, string functionName, DateTime nextSchedule);
+
+    [LoggerMessage(LogLevel.Information, message: "[{FunctionName}] -> Added {RolloverCandidatesCreated} qualifications as rollover candidates.")]
+    public static partial void CandidatesCreated(this ILogger logger, string functionName, int rolloverCandidatesCreated);
+
+    [LoggerMessage(LogLevel.Information, message: "[{FunctionName}] -> No qualification versions were added as rollover candidates.")]
+    public static partial void NoCandidatesCreated(this ILogger logger, string functionName);
+
+    [LoggerMessage(LogLevel.Error, message: "[{FunctionName}] -> Rollover candidate generation failed.")]
+    public static partial void GenerationFailed(this ILogger logger, Exception exception, string functionName);
+
+    [LoggerMessage(LogLevel.Error, message: "[{FunctionName}] -> Failed to mark rollover candidate job run as errored.")]
+    public static partial void FailedToMarkJobRunAsErrored(this ILogger logger, Exception exception, string functionName);
+}

--- a/src/SFA.DAS.AODP.Jobs/Models/Rollover/AcademicYear.cs
+++ b/src/SFA.DAS.AODP.Jobs/Models/Rollover/AcademicYear.cs
@@ -1,0 +1,15 @@
+namespace SFA.DAS.AODP.Jobs.Models.Rollover;
+
+public sealed record AcademicYear(string Name, DateOnly StartDate, DateOnly EndDate)
+{
+    public static AcademicYear FromDate(DateTime date)
+    {
+        var startYear = date.Month >= 8 ? date.Year : date.Year - 1;
+        var endYear = startYear + 1;
+
+        return new AcademicYear(
+            $"{startYear}/{endYear % 100:00}",
+            new DateOnly(startYear, 8, 1),
+            new DateOnly(endYear, 7, 31));
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs/Services/JobConfigurationService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/JobConfigurationService.cs
@@ -33,6 +33,7 @@
                 JobNames.Pldns => await ReadPldnsImportConfiguration(),
                 JobNames.DefundingList => await ReadDefundingListImportConfiguration(),
                 JobNames.QaaQualifications => await ReadQaaQualificationJobConfiguration(),
+                JobNames.RolloverCandidates => await ReadSimpleJobConfiguration(jobName),
                 _ => throw new ArgumentOutOfRangeException(nameof(jobName), jobName, null)
             };
 
@@ -156,6 +157,18 @@
                 var runApiImport = jobRecord!.JobConfigurations.FirstOrDefault(o => o.Name == nameof(JobConfiguration.ImportQaaQualifications))?.Value ?? "false";
                 jobControl.RunApiImport = bool.Parse(runApiImport);
             }
+
+            return jobControl;
+        }
+
+        private async Task<JobControl> ReadSimpleJobConfiguration(JobNames jobName)
+        {
+            var jobControl = new JobControl();
+            var jobRecord = await _jobsRepository.GetJobByNameAsync(jobName.ToString());
+
+            jobControl.JobEnabled = jobRecord?.Enabled ?? false;
+            jobControl.JobId = jobRecord?.Id ?? Guid.Empty;
+            jobControl.Status = jobRecord?.Status ?? string.Empty;
 
             return jobControl;
         }

--- a/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
@@ -1,6 +1,6 @@
 using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Infrastructure.Models;
 using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
-using SFA.DAS.AODP.Jobs.Models.Rollover;
 
 namespace SFA.DAS.AODP.Jobs.Services.Rollover;
 
@@ -15,9 +15,7 @@ public class RolloverCandidateService(
         var academicYear = AcademicYear.FromDate(now);
 
         return repository.CreateInitialRolloverCandidatesAsync(
-            academicYear.Name,
-            academicYear.EndDate,
-            now,
+            AcademicYear.NextAcademicYear(academicYear),
             cancellationToken);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
@@ -15,7 +15,7 @@ public class RolloverCandidateService(
         var academicYear = AcademicYear.FromDate(now);
 
         return repository.CreateInitialRolloverCandidatesAsync(
-            AcademicYear.NextAcademicYear(academicYear),
+            academicYear,
             cancellationToken);
     }
 }

--- a/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
@@ -1,0 +1,32 @@
+using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.Models.Rollover;
+using SFA.DAS.Funding.ApprenticeshipEarnings.Domain.Services;
+
+namespace SFA.DAS.AODP.Jobs.Services.Rollover;
+
+public class RolloverCandidateService : IRolloverCandidateService
+{
+    private readonly IRolloverCandidateRepository _repository;
+    private readonly ISystemClockService _systemClockService;
+
+    public RolloverCandidateService(
+        IRolloverCandidateRepository repository,
+        ISystemClockService systemClockService)
+    {
+        _repository = repository;
+        _systemClockService = systemClockService;
+    }
+
+    public Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken = default)
+    {
+        var now = _systemClockService.UtcNow;
+        var academicYear = AcademicYear.FromDate(now);
+
+        return _repository.CreateInitialRolloverCandidatesAsync(
+            academicYear.Name,
+            academicYear.EndDate,
+            now,
+            cancellationToken);
+    }
+}

--- a/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
+++ b/src/SFA.DAS.AODP.Jobs/Services/Rollover/RolloverCandidateService.cs
@@ -1,29 +1,20 @@
 using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
 using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
 using SFA.DAS.AODP.Jobs.Models.Rollover;
-using SFA.DAS.Funding.ApprenticeshipEarnings.Domain.Services;
 
 namespace SFA.DAS.AODP.Jobs.Services.Rollover;
 
-public class RolloverCandidateService : IRolloverCandidateService
+public class RolloverCandidateService(
+    IRolloverCandidateRepository repository,
+    ISystemClockService systemClockService)
+    : IRolloverCandidateService
 {
-    private readonly IRolloverCandidateRepository _repository;
-    private readonly ISystemClockService _systemClockService;
-
-    public RolloverCandidateService(
-        IRolloverCandidateRepository repository,
-        ISystemClockService systemClockService)
+    public Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken)
     {
-        _repository = repository;
-        _systemClockService = systemClockService;
-    }
-
-    public Task<int> GenerateRolloverCandidatesAsync(CancellationToken cancellationToken = default)
-    {
-        var now = _systemClockService.UtcNow;
+        var now = systemClockService.UtcNow;
         var academicYear = AcademicYear.FromDate(now);
 
-        return _repository.CreateInitialRolloverCandidatesAsync(
+        return repository.CreateInitialRolloverCandidatesAsync(
             academicYear.Name,
             academicYear.EndDate,
             now,

--- a/src/SFA.DAS.AODP.Jobs/StartupExtensions/AddServiceRegistrationsExtension.cs
+++ b/src/SFA.DAS.AODP.Jobs/StartupExtensions/AddServiceRegistrationsExtension.cs
@@ -1,4 +1,8 @@
 ﻿using SFA.DAS.AODP.Jobs.Functions.Abstractions;
+using SFA.DAS.AODP.Infrastructure.Interfaces.Rollover;
+using SFA.DAS.AODP.Infrastructure.Repositories.Rollover;
+using SFA.DAS.AODP.Jobs.Interfaces.Rollover;
+using SFA.DAS.AODP.Jobs.Services.Rollover;
 
 namespace SFA.DAS.AODP.Jobs.StartupExtensions;
 
@@ -39,6 +43,8 @@ public static class AddServiceRegistrationsExtension
         services.AddScoped<IQualificationsRepository, QualificationsRepository>();
         services.AddScoped<IQualificationVersionRepository, QualificationVersionRepository>();
         services.AddScoped<IImportRepository, ImportRepository>();
+        services.AddScoped<IRolloverCandidateRepository, RolloverCandidateRepository>();
+        services.AddScoped<IRolloverCandidateService, RolloverCandidateService>();
         services.AddAzureClients(clientBuilder =>
         {
             clientBuilder.AddBlobServiceClient(configuration.GetValue<string>("BlobStorageSettings:ConnectionString"));

--- a/src/SFA.DAS.AODP.Jobs/appsettings.json
+++ b/src/SFA.DAS.AODP.Jobs/appsettings.json
@@ -2,6 +2,7 @@
   "AodpJobsConfiguration": {
     "DbConnectionString": "Data Source=localhost;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;Initial Catalog=SFA.DAS.AODP.Database"
   },
+  "RolloverCandidatesTimerSchedule": "0 0 2 1 8 *",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
   "ConfigNames": "SFA.DAS.AODP.Jobs",
   "EnvironmentName": "LOCAL"

--- a/src/SFA.DAS.AODP.Jobs/appsettings.json
+++ b/src/SFA.DAS.AODP.Jobs/appsettings.json
@@ -2,7 +2,6 @@
   "AodpJobsConfiguration": {
     "DbConnectionString": "Data Source=localhost;Integrated Security=True;Encrypt=True;TrustServerCertificate=True;Initial Catalog=SFA.DAS.AODP.Database"
   },
-  "RolloverCandidatesTimerSchedule": "0 0 2 1 8 *",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
   "ConfigNames": "SFA.DAS.AODP.Jobs",
   "EnvironmentName": "LOCAL"


### PR DESCRIPTION
[AWARD-1078]

- Added new scheduled job that inserts rollover candidates each year
- Criteria is latest qualification version per funding stream where the funding stream is active and has an open ended EndDate OR ends in the next academic year.

[AWARD-1078]: https://skillsfundingagency.atlassian.net/browse/AWARD-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ